### PR TITLE
feat: 다크모드/라이트모드 토글 기능 구현

### DIFF
--- a/app/(main)/archive/_components/ArchiveAccordion.tsx
+++ b/app/(main)/archive/_components/ArchiveAccordion.tsx
@@ -39,7 +39,7 @@ export function ArchiveAccordion({
 
   if (tournaments.length === 0) {
     return (
-      <div className="flex items-center justify-center py-12 text-gray-500 dark:text-gray-400">
+      <div className="flex items-center justify-center py-12 text-muted-foreground">
         <p className="text-sm">No tournaments available</p>
       </div>
     )
@@ -48,14 +48,14 @@ export function ArchiveAccordion({
   return (
     <div className="space-y-4">
       {tournaments.map((tournament) => (
-        <details key={tournament.id} className="group bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden">
-          <summary className="flex items-center justify-between p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
+        <details key={tournament.id} className="group bg-card rounded-lg shadow-md overflow-hidden">
+          <summary className="flex items-center justify-between p-4 cursor-pointer hover:bg-accent transition-colors">
             <div className="flex items-center gap-3">
               <ChevronRight className="w-5 h-5 transition-transform group-open:rotate-90" />
               <Trophy className="w-5 h-5 text-yellow-500" />
               <div>
                 <h3 className="text-lg font-bold">{tournament.name}</h3>
-                <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
                   <MapPin className="w-4 h-4" />
                   <span>{tournament.location}</span>
                   <Calendar className="w-4 h-4 ml-2" />
@@ -66,18 +66,18 @@ export function ArchiveAccordion({
             <Badge color="info">{tournament.events?.length || 0} Events</Badge>
           </summary>
 
-          <div className="p-4 border-t border-gray-200 dark:border-gray-700">
+          <div className="p-4 border-t border-border">
             {/* Events */}
             {tournament.events && tournament.events.length > 0 ? (
               <div className="space-y-3">
                 {tournament.events.map((event) => (
-                  <details key={event.id} className="group/event bg-gray-50 dark:bg-gray-900 rounded-lg overflow-hidden">
-                    <summary className="flex items-center justify-between p-3 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+                  <details key={event.id} className="group/event bg-muted rounded-lg overflow-hidden">
+                    <summary className="flex items-center justify-between p-3 cursor-pointer hover:bg-accent transition-colors">
                       <div className="flex items-center gap-2">
                         <ChevronRight className="w-4 h-4 transition-transform group-open/event:rotate-90" />
                         <div>
                           <h4 className="font-semibold">{event.name}</h4>
-                          <p className="text-sm text-gray-600 dark:text-gray-400">
+                          <p className="text-sm text-muted-foreground">
                             {event.date} • {event.buy_in || 'N/A'}
                           </p>
                         </div>
@@ -85,13 +85,13 @@ export function ArchiveAccordion({
                       <Badge color="success">{event.streams?.length || 0} Streams</Badge>
                     </summary>
 
-                    <div className="p-3 border-t border-gray-200 dark:border-gray-700">
+                    <div className="p-3 border-t border-border">
                       {/* Streams */}
                       {event.streams && event.streams.length > 0 ? (
                         <div className="space-y-2">
                           {event.streams.map((stream) => (
-                            <details key={stream.id} className="group/stream bg-white dark:bg-gray-800 rounded-lg overflow-hidden">
-                              <summary className="flex items-center justify-between p-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
+                            <details key={stream.id} className="group/stream bg-card rounded-lg overflow-hidden">
+                              <summary className="flex items-center justify-between p-3 cursor-pointer hover:bg-accent transition-colors">
                                 <div className="flex items-center gap-2">
                                   <ChevronRight className="w-4 h-4 transition-transform group-open/stream:rotate-90" />
                                   <Video className="w-4 h-4" />
@@ -102,7 +102,7 @@ export function ArchiveAccordion({
                                 </Badge>
                               </summary>
 
-                              <div className="p-3 border-t border-gray-200 dark:border-gray-700">
+                              <div className="p-3 border-t border-border">
                                 {/* Virtual Hand List */}
                                 <VirtualHandList
                                   hands={hands.get(stream.id) || []}
@@ -114,7 +114,7 @@ export function ArchiveAccordion({
                           ))}
                         </div>
                       ) : (
-                        <div className="text-center py-8 text-gray-500">
+                        <div className="text-center py-8 text-muted-foreground">
                           <p className="text-sm">No streams available</p>
                           {isAdmin && onAddStream && (
                             <Button
@@ -134,7 +134,7 @@ export function ArchiveAccordion({
                 ))}
               </div>
             ) : (
-              <div className="text-center py-8 text-gray-500">
+              <div className="text-center py-8 text-muted-foreground">
                 <p className="text-sm">No events available</p>
                 {isAdmin && onAddEvent && (
                   <Button

--- a/app/(main)/archive/_components/ArchiveDashboard.tsx
+++ b/app/(main)/archive/_components/ArchiveDashboard.tsx
@@ -47,12 +47,12 @@ export function ArchiveDashboard({ tournaments }: ArchiveDashboardProps) {
   }, [tournaments])
 
   return (
-    <div data-testid="archive-dashboard" className="flex-1 overflow-auto bg-gray-50 dark:bg-gray-900 p-6">
+    <div data-testid="archive-dashboard" className="flex-1 overflow-auto bg-background p-6">
       <div className="max-w-7xl mx-auto space-y-6">
         {/* Header */}
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Archive Dashboard</h1>
-          <p data-testid="dashboard-hint" className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+          <h1 className="text-2xl font-bold text-foreground">Archive Dashboard</h1>
+          <p data-testid="dashboard-hint" className="text-sm text-muted-foreground mt-1">
             왼쪽에서 스트림을 선택하면 핸드 히스토리를 확인할 수 있습니다.
           </p>
         </div>
@@ -86,17 +86,17 @@ export function ArchiveDashboard({ tournaments }: ArchiveDashboardProps) {
         </div>
 
         {/* 카테고리별 분포 */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-          <h2 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">
+        <div className="bg-card rounded-lg p-6 border border-border">
+          <h2 className="text-lg font-semibold mb-4 text-foreground">
             Category Distribution
           </h2>
           <div className="space-y-3">
             {categoryStats.map(({ name, tournaments: count }) => (
               <div key={name} className="flex items-center gap-3">
-                <div className="w-32 text-sm font-medium text-gray-700 dark:text-gray-300 truncate">
+                <div className="w-32 text-sm font-medium text-foreground truncate">
                   {name}
                 </div>
-                <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded-full h-8 overflow-hidden">
+                <div className="flex-1 bg-muted rounded-full h-8 overflow-hidden">
                   <div
                     className="bg-green-600 dark:bg-green-500 h-full flex items-center justify-end px-3 text-xs text-white font-semibold transition-all"
                     style={{ width: `${(count / stats.totalTournaments) * 100}%` }}
@@ -104,7 +104,7 @@ export function ArchiveDashboard({ tournaments }: ArchiveDashboardProps) {
                     {count > 0 && count}
                   </div>
                 </div>
-                <div className="w-20 text-right text-sm text-gray-600 dark:text-gray-400">
+                <div className="w-20 text-right text-sm text-muted-foreground">
                   {((count / stats.totalTournaments) * 100).toFixed(1)}%
                 </div>
               </div>
@@ -112,18 +112,18 @@ export function ArchiveDashboard({ tournaments }: ArchiveDashboardProps) {
           </div>
 
           {categoryStats.length === 0 && (
-            <div className="text-center py-8 text-sm text-gray-500 dark:text-gray-400">
+            <div className="text-center py-8 text-sm text-muted-foreground">
               카테고리 데이터가 없습니다
             </div>
           )}
         </div>
 
         {/* Recent Activity Placeholder */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-          <h2 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">
+        <div className="bg-card rounded-lg p-6 border border-border">
+          <h2 className="text-lg font-semibold mb-4 text-foreground">
             Recent Hands
           </h2>
-          <div className="text-center py-8 text-sm text-gray-500 dark:text-gray-400">
+          <div className="text-center py-8 text-sm text-muted-foreground">
             최근 핸드 데이터를 보려면 스트림을 선택하세요
           </div>
         </div>
@@ -147,14 +147,14 @@ function StatCard({ icon: Icon, label, value, color }: {
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700 hover:shadow-lg transition-shadow">
+    <div className="bg-card rounded-lg p-6 border border-border hover:shadow-lg transition-shadow">
       <div className="flex items-center gap-3">
         <div className={cn("p-3 rounded-lg", colorClasses[color])}>
           <Icon className="w-6 h-6" />
         </div>
         <div className="flex-1">
-          <div className="text-sm text-gray-600 dark:text-gray-400">{label}</div>
-          <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+          <div className="text-sm text-muted-foreground">{label}</div>
+          <div className="text-2xl font-bold text-foreground">
             {value.toLocaleString()}
           </div>
         </div>

--- a/app/(main)/archive/_components/ArchiveFilterSidebar.tsx
+++ b/app/(main)/archive/_components/ArchiveFilterSidebar.tsx
@@ -51,11 +51,11 @@ export function ArchiveFilterSidebar({
   const [isHandRangeExpanded, setIsHandRangeExpanded] = useState(false)
 
   return (
-    <div className="flex flex-col h-full bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700">
+    <div className="flex flex-col h-full bg-card border-r border-border">
       {/* Header */}
-      <div className="p-4 border-b border-gray-200 dark:border-gray-700">
-        <h2 className="font-semibold text-lg text-gray-900 dark:text-gray-100">Filters</h2>
-        <p className="text-sm text-gray-600 dark:text-gray-400">
+      <div className="p-4 border-b border-border">
+        <h2 className="font-semibold text-lg text-foreground">Filters</h2>
+        <p className="text-sm text-muted-foreground">
           토너먼트 필터링
         </p>
       </div>
@@ -66,16 +66,16 @@ export function ArchiveFilterSidebar({
           <div>
             <button
               onClick={() => setIsCategoryExpanded(!isCategoryExpanded)}
-              className="w-full flex items-center justify-between mb-3 text-sm font-medium text-gray-900 dark:text-gray-100"
+              className="w-full flex items-center justify-between mb-3 text-sm font-medium text-foreground"
             >
               <div className="flex items-center gap-2">
-                <Trophy className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                <Trophy className="h-4 w-4 text-muted-foreground" />
                 <span>Category</span>
               </div>
               {isCategoryExpanded ? (
-                <ChevronDown className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
               ) : (
-                <ChevronRight className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
               )}
             </button>
 
@@ -91,7 +91,7 @@ export function ArchiveFilterSidebar({
                       className={`w-full flex items-center justify-between p-2 rounded-md text-sm transition-colors ${
                         isSelected
                           ? 'bg-green-100 dark:bg-green-900/30 text-green-900 dark:text-green-100'
-                          : 'hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300'
+                          : 'hover:bg-accent text-foreground'
                       }`}
                     >
                       <span className="truncate">{category}</span>
@@ -100,7 +100,7 @@ export function ArchiveFilterSidebar({
                         className={`ml-2 ${
                           isSelected
                             ? 'bg-green-600 dark:bg-green-700'
-                            : 'bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300'
+                            : 'bg-muted text-foreground'
                         }`}
                       >
                         {count}
@@ -112,22 +112,22 @@ export function ArchiveFilterSidebar({
             )}
           </div>
 
-          <Separator className="bg-gray-200 dark:bg-gray-700" />
+          <Separator className="bg-border" />
 
           {/* Location Filter */}
           <div>
             <button
               onClick={() => setIsLocationExpanded(!isLocationExpanded)}
-              className="w-full flex items-center justify-between mb-3 text-sm font-medium text-gray-900 dark:text-gray-100"
+              className="w-full flex items-center justify-between mb-3 text-sm font-medium text-foreground"
             >
               <div className="flex items-center gap-2">
-                <MapPin className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                <MapPin className="h-4 w-4 text-muted-foreground" />
                 <span>Location</span>
               </div>
               {isLocationExpanded ? (
-                <ChevronDown className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
               ) : (
-                <ChevronRight className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
               )}
             </button>
 
@@ -143,7 +143,7 @@ export function ArchiveFilterSidebar({
                       className={`w-full flex items-center justify-between p-2 rounded-md text-sm transition-colors ${
                         isSelected
                           ? 'bg-green-100 dark:bg-green-900/30 text-green-900 dark:text-green-100'
-                          : 'hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300'
+                          : 'hover:bg-accent text-foreground'
                       }`}
                     >
                       <span className="truncate">{location}</span>
@@ -152,7 +152,7 @@ export function ArchiveFilterSidebar({
                         className={`ml-2 ${
                           isSelected
                             ? 'bg-green-600 dark:bg-green-700'
-                            : 'bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300'
+                            : 'bg-muted text-foreground'
                         }`}
                       >
                         {count}
@@ -164,29 +164,29 @@ export function ArchiveFilterSidebar({
             )}
           </div>
 
-          <Separator className="bg-gray-200 dark:bg-gray-700" />
+          <Separator className="bg-border" />
 
           {/* Date Range Filter */}
           <div>
             <button
               onClick={() => setIsDateExpanded(!isDateExpanded)}
-              className="w-full flex items-center justify-between mb-3 text-sm font-medium text-gray-900 dark:text-gray-100"
+              className="w-full flex items-center justify-between mb-3 text-sm font-medium text-foreground"
             >
               <div className="flex items-center gap-2">
-                <Calendar className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                <Calendar className="h-4 w-4 text-muted-foreground" />
                 <span>Date Range</span>
               </div>
               {isDateExpanded ? (
-                <ChevronDown className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
               ) : (
-                <ChevronRight className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
               )}
             </button>
 
             {isDateExpanded && (
               <div className="space-y-2">
                 <div>
-                  <label className="text-xs text-gray-600 dark:text-gray-400 mb-1 block">
+                  <label className="text-xs text-muted-foreground mb-1 block">
                     Start Date
                   </label>
                   <input
@@ -196,11 +196,11 @@ export function ArchiveFilterSidebar({
                       ...selectedDateRange,
                       start: e.target.value || null
                     })}
-                    className="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-md text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-green-400"
+                    className="w-full px-3 py-2 bg-card border border-border rounded-md text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-green-400"
                   />
                 </div>
                 <div>
-                  <label className="text-xs text-gray-600 dark:text-gray-400 mb-1 block">
+                  <label className="text-xs text-muted-foreground mb-1 block">
                     End Date
                   </label>
                   <input
@@ -210,36 +210,36 @@ export function ArchiveFilterSidebar({
                       ...selectedDateRange,
                       end: e.target.value || null
                     })}
-                    className="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-md text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-green-400"
+                    className="w-full px-3 py-2 bg-card border border-border rounded-md text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-green-400"
                   />
                 </div>
               </div>
             )}
           </div>
 
-          <Separator className="bg-gray-200 dark:bg-gray-700" />
+          <Separator className="bg-border" />
 
           {/* Hand Count Range Filter */}
           <div>
             <button
               onClick={() => setIsHandRangeExpanded(!isHandRangeExpanded)}
-              className="w-full flex items-center justify-between mb-3 text-sm font-medium text-gray-900 dark:text-gray-100"
+              className="w-full flex items-center justify-between mb-3 text-sm font-medium text-foreground"
             >
               <div className="flex items-center gap-2">
-                <Hash className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                <Hash className="h-4 w-4 text-muted-foreground" />
                 <span>Hand Count</span>
               </div>
               {isHandRangeExpanded ? (
-                <ChevronDown className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
               ) : (
-                <ChevronRight className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
               )}
             </button>
 
             {isHandRangeExpanded && (
               <div className="space-y-2">
                 <div>
-                  <label className="text-xs text-gray-600 dark:text-gray-400 mb-1 block">
+                  <label className="text-xs text-muted-foreground mb-1 block">
                     Min Hands
                   </label>
                   <input
@@ -251,11 +251,11 @@ export function ArchiveFilterSidebar({
                       ...selectedHandRange,
                       min: e.target.value ? parseInt(e.target.value) : null
                     })}
-                    className="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-md text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-green-400"
+                    className="w-full px-3 py-2 bg-card border border-border rounded-md text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-green-400"
                   />
                 </div>
                 <div>
-                  <label className="text-xs text-gray-600 dark:text-gray-400 mb-1 block">
+                  <label className="text-xs text-muted-foreground mb-1 block">
                     Max Hands
                   </label>
                   <input
@@ -267,7 +267,7 @@ export function ArchiveFilterSidebar({
                       ...selectedHandRange,
                       max: e.target.value ? parseInt(e.target.value) : null
                     })}
-                    className="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-md text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-green-400"
+                    className="w-full px-3 py-2 bg-card border border-border rounded-md text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-green-400"
                   />
                 </div>
               </div>
@@ -276,13 +276,13 @@ export function ArchiveFilterSidebar({
         </div>
       </ScrollArea>
 
-      <Separator className="bg-gray-200 dark:bg-gray-700" />
+      <Separator className="bg-border" />
 
       {/* Footer Actions */}
       <div className="p-4">
         <Button
           variant="ghost"
-          className="w-full rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300"
+          className="w-full rounded-lg hover:bg-accent text-foreground"
           onClick={onReset}
         >
           <RotateCcw className="h-4 w-4 mr-2" />

--- a/app/(main)/archive/_components/ArchiveNavigationSidebar.tsx
+++ b/app/(main)/archive/_components/ArchiveNavigationSidebar.tsx
@@ -39,21 +39,21 @@ export function ArchiveNavigationSidebar({
   )
 
   return (
-    <div className="flex flex-col h-full bg-white dark:bg-gray-800">
+    <div className="flex flex-col h-full bg-card">
       {/* 검색바 */}
-      <div className="p-4 border-b border-gray-200 dark:border-gray-700">
+      <div className="p-4 border-b border-border">
         <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 dark:text-gray-500" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <input
             type="text"
             placeholder="토너먼트/이벤트 검색..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             data-testid="archive-search"
-            className="w-full pl-10 pr-4 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-lg text-sm text-gray-900 dark:text-gray-100 placeholder:text-gray-500 dark:placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-green-400 focus:border-transparent transition-all"
+            className="w-full pl-10 pr-4 py-2 bg-background border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-green-400 focus:border-transparent transition-all"
           />
         </div>
-        <div className="mt-2 text-xs text-gray-600 dark:text-gray-400">
+        <div className="mt-2 text-xs text-muted-foreground">
           {filteredTournaments.length} tournaments
         </div>
       </div>
@@ -69,19 +69,19 @@ export function ArchiveNavigationSidebar({
                 className="border-none"
               >
                 {/* Tournament Header */}
-                <AccordionTrigger className="px-3 py-2 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-md hover:no-underline">
+                <AccordionTrigger className="px-3 py-2 hover:bg-accent rounded-md hover:no-underline">
                   <div className="flex items-center gap-2 text-left w-full">
                     <Avatar className="w-8 h-8 rounded">
                       <AvatarImage src={tournament.category_logo_url} alt={tournament.name} />
-                      <AvatarFallback className="text-xs bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded">
+                      <AvatarFallback className="text-xs bg-muted text-foreground rounded">
                         {tournament.name.substring(0, 2).toUpperCase()}
                       </AvatarFallback>
                     </Avatar>
                     <div className="flex-1 min-w-0">
-                      <div className="text-sm font-medium truncate text-gray-900 dark:text-gray-100">
+                      <div className="text-sm font-medium truncate text-foreground">
                         {tournament.name}
                       </div>
-                      <div className="text-xs text-gray-500 dark:text-gray-400">
+                      <div className="text-xs text-muted-foreground">
                         {tournament.events?.length || 0} events
                       </div>
                     </div>
@@ -99,14 +99,14 @@ export function ArchiveNavigationSidebar({
                           className="border-none"
                         >
                           {/* Event Header */}
-                          <AccordionTrigger className="px-3 py-2 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-md text-sm hover:no-underline">
+                          <AccordionTrigger className="px-3 py-2 hover:bg-accent rounded-md text-sm hover:no-underline">
                             <div className="flex items-center gap-2 text-left w-full">
-                              <Trophy className="w-4 h-4 text-gray-400 dark:text-gray-500 flex-shrink-0" />
+                              <Trophy className="w-4 h-4 text-muted-foreground flex-shrink-0" />
                               <div className="flex-1 min-w-0">
-                                <div className="font-medium truncate text-gray-900 dark:text-gray-100">
+                                <div className="font-medium truncate text-foreground">
                                   {event.name}
                                 </div>
-                                <div className="text-xs text-gray-500 dark:text-gray-400">
+                                <div className="text-xs text-muted-foreground">
                                   {event.streams?.length || 0} streams
                                 </div>
                               </div>
@@ -129,14 +129,14 @@ export function ArchiveNavigationSidebar({
                                         "w-full px-3 py-2 text-left rounded-md text-sm transition-colors",
                                         selectedStreamId === stream.id
                                           ? "bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 font-medium"
-                                          : "hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300"
+                                          : "hover:bg-accent text-foreground"
                                       )}
                                     >
                                       <div className="flex items-center gap-2">
                                         <Video className="w-4 h-4 flex-shrink-0" />
                                         <div className="flex-1 min-w-0">
                                           <div className="truncate">{stream.name}</div>
-                                          <div className="text-xs text-gray-500 dark:text-gray-400">
+                                          <div className="text-xs text-muted-foreground">
                                             {handCount} hands
                                           </div>
                                         </div>
@@ -146,7 +146,7 @@ export function ArchiveNavigationSidebar({
                                 })}
                               </div>
                             ) : (
-                              <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
+                              <div className="px-3 py-2 text-xs text-muted-foreground">
                                 스트림 없음
                               </div>
                             )}
@@ -155,7 +155,7 @@ export function ArchiveNavigationSidebar({
                       ))}
                     </Accordion>
                   ) : (
-                    <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
+                    <div className="px-3 py-2 text-xs text-muted-foreground">
                       이벤트 없음
                     </div>
                   )}
@@ -165,7 +165,7 @@ export function ArchiveNavigationSidebar({
           </Accordion>
 
           {filteredTournaments.length === 0 && (
-            <div className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
               검색 결과가 없습니다
             </div>
           )}

--- a/app/(main)/archive/_components/ArchiveSidebarCategories.tsx
+++ b/app/(main)/archive/_components/ArchiveSidebarCategories.tsx
@@ -105,7 +105,7 @@ export function ArchiveSidebarCategories({
           "w-full flex items-center gap-3 px-4 h-12 text-sm font-medium rounded-lg transition-colors overflow-hidden",
           selectedCategory === 'All'
             ? "bg-gold-600 text-white"
-            : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+            : "text-foreground hover:bg-accent"
         )}
       >
         <LayoutGrid className="w-5 h-5 flex-shrink-0" />
@@ -132,12 +132,12 @@ export function ArchiveSidebarCategories({
                   <button
                     type="button"
                     onClick={() => toggleParent(category.id)}
-                    className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors flex-shrink-0"
+                    className="p-2 hover:bg-accent rounded-md transition-colors flex-shrink-0"
                     aria-label={isExpanded ? 'Collapse' : 'Expand'}
                   >
                     <ChevronRight
                       className={cn(
-                        "w-4 h-4 text-gray-500 transition-transform",
+                        "w-4 h-4 text-muted-foreground transition-transform",
                         isExpanded && "rotate-90"
                       )}
                     />
@@ -153,7 +153,7 @@ export function ArchiveSidebarCategories({
                     "flex-1 flex items-center gap-3 px-3 h-11 text-sm font-medium rounded-lg transition-colors overflow-hidden",
                     isSelected
                       ? "bg-gold-600 text-white"
-                      : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+                      : "text-foreground hover:bg-accent"
                   )}
                 >
                   <CategoryLogo
@@ -173,7 +173,7 @@ export function ArchiveSidebarCategories({
 
               {/* Child Categories */}
               {isExpanded && hasChildren && (
-                <ul className="ml-10 mt-2 space-y-0.5 border-l-2 border-gray-200 dark:border-gray-700 pl-3 overflow-hidden">
+                <ul className="ml-10 mt-2 space-y-0.5 border-l-2 border-border pl-3 overflow-hidden">
                   {children.map((child) => {
                     const isChildSelected = selectedCategory === child.id
                     return (
@@ -185,7 +185,7 @@ export function ArchiveSidebarCategories({
                             "w-full flex items-center gap-2.5 px-3 h-9 text-sm rounded-lg transition-colors overflow-hidden",
                             isChildSelected
                               ? "bg-gold-600 text-white font-medium"
-                              : "text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+                              : "text-muted-foreground hover:bg-accent"
                           )}
                         >
                           <CategoryLogo

--- a/app/(main)/archive/_components/HandDetailDialog.tsx
+++ b/app/(main)/archive/_components/HandDetailDialog.tsx
@@ -49,7 +49,7 @@ function PlayingCard({ card }: { card: string }) {
   return (
     <div
       className={`w-8 h-11 rounded border bg-white flex flex-col items-center justify-center font-bold text-xs shadow-sm ${
-        isRed ? "text-red-600 border-red-300" : "text-gray-900 border-gray-300"
+        isRed ? "text-red-600 border-red-300" : "text-foreground border-border"
       }`}
     >
       <div>{rank}</div>
@@ -235,7 +235,7 @@ export function HandDetailDialog({ handId, open, onOpenChange }: HandDetailDialo
             )}
           </DialogTitle>
           {hand && (
-            <div className="text-sm text-gray-400">
+            <div className="text-sm text-muted-foreground">
               {tournament?.name}
               {hand.stream?.name && ` - ${hand.stream.name}`}
               {hand.stakes && ` - ${hand.stakes}`}
@@ -250,7 +250,7 @@ export function HandDetailDialog({ handId, open, onOpenChange }: HandDetailDialo
                 <Loader2 className="w-8 h-8 animate-spin text-green-500" />
               </div>
             ) : !hand ? (
-              <div className="text-center py-12 text-gray-400">
+              <div className="text-center py-12 text-muted-foreground">
                 핸드를 찾을 수 없습니다
               </div>
             ) : (
@@ -258,7 +258,7 @@ export function HandDetailDialog({ handId, open, onOpenChange }: HandDetailDialo
                 {/* Pot Size */}
                 {hand.potSize && (
                   <div className="bg-green-900/20 border border-green-800 rounded-lg p-4">
-                    <div className="text-sm text-gray-400">최종 팟</div>
+                    <div className="text-sm text-muted-foreground">최종 팟</div>
                     <div className="text-xl font-bold text-green-400">
                       {hand.potSize.toLocaleString()} chips
                     </div>
@@ -275,8 +275,8 @@ export function HandDetailDialog({ handId, open, onOpenChange }: HandDetailDialo
 
                 {/* Board Cards */}
                 {(hand.boardFlop || hand.boardTurn || hand.boardRiver) && (
-                  <div className="bg-gray-800 rounded-lg p-4">
-                    <div className="text-sm font-semibold text-gray-300 mb-3">보드</div>
+                  <div className="bg-card rounded-lg p-4">
+                    <div className="text-sm font-semibold text-foreground mb-3">보드</div>
                     <div className="flex gap-2 flex-wrap">
                       {hand.boardFlop && hand.boardFlop.map((card: string, i: number) => (
                         <PlayingCard key={`flop-${i}`} card={card} />
@@ -289,13 +289,13 @@ export function HandDetailDialog({ handId, open, onOpenChange }: HandDetailDialo
 
                 {/* Players */}
                 {hand.players && hand.players.length > 0 && (
-                  <div className="bg-gray-800 rounded-lg p-4">
-                    <div className="text-sm font-semibold text-gray-300 mb-3">플레이어</div>
+                  <div className="bg-card rounded-lg p-4">
+                    <div className="text-sm font-semibold text-foreground mb-3">플레이어</div>
                     <div className="space-y-2">
                       {hand.players.map((hp) => (
                         <div
                           key={hp.id}
-                          className="flex items-center justify-between p-2 bg-gray-900 rounded"
+                          className="flex items-center justify-between p-2 bg-muted rounded"
                         >
                           <div className="flex items-center gap-2">
                             <Avatar className="w-8 h-8">
@@ -305,10 +305,10 @@ export function HandDetailDialog({ handId, open, onOpenChange }: HandDetailDialo
                               </AvatarFallback>
                             </Avatar>
                             <div>
-                              <div className="text-sm font-medium text-gray-200">
+                              <div className="text-sm font-medium text-foreground">
                                 {hp.name}
                               </div>
-                              <div className="text-xs text-gray-500">
+                              <div className="text-xs text-muted-foreground">
                                 {hp.position || "-"}
                               </div>
                             </div>
@@ -335,21 +335,21 @@ export function HandDetailDialog({ handId, open, onOpenChange }: HandDetailDialo
 
                 {/* Actions */}
                 {hand.actions && hand.actions.length > 0 && (
-                  <div className="bg-gray-800 rounded-lg p-4">
-                    <div className="text-sm font-semibold text-gray-300 mb-3">액션</div>
+                  <div className="bg-card rounded-lg p-4">
+                    <div className="text-sm font-semibold text-foreground mb-3">액션</div>
                     <div className="space-y-1">
                       {hand.actions
                         .sort((a, b) => (a.sequence || 0) - (b.sequence || 0))
                         .map((action) => (
                           <div
                             key={action.id}
-                            className="flex items-center gap-2 p-2 bg-gray-900 rounded text-sm"
+                            className="flex items-center gap-2 p-2 bg-muted rounded text-sm"
                           >
                             <Badge variant="outline" className="text-xs w-16 justify-center">
                               {action.street}
                             </Badge>
-                            <span className="text-gray-300 flex-1">{action.playerName}</span>
-                            <span className="text-gray-400 capitalize">{action.actionType}</span>
+                            <span className="text-foreground flex-1">{action.playerName}</span>
+                            <span className="text-muted-foreground capitalize">{action.actionType}</span>
                             {action.amount && action.amount > 0 && (
                               <span className="text-green-400 font-medium">
                                 {action.amount.toLocaleString()}

--- a/app/(main)/archive/_components/HandListItem.tsx
+++ b/app/(main)/archive/_components/HandListItem.tsx
@@ -43,7 +43,7 @@ export const HandListItem = memo(function HandListItem({
       className={`card-postmodern hand-list-item mb-3 p-4 rounded-lg hover:shadow-lg transition-all cursor-pointer ${
         isSelected
           ? 'bg-green-50 dark:bg-green-900/20 border-2 border-green-500 dark:border-green-600'
-          : 'bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700'
+          : 'bg-card border border-border'
       }`}
       onClick={handleCardClick}
     >
@@ -55,18 +55,18 @@ export const HandListItem = memo(function HandListItem({
           </Badge>
           {/* 타임코드 표시: video_timestamp가 있으면 사용, 없으면 timestamp 필드 fallback */}
           {(hand.video_timestamp_start !== undefined && hand.video_timestamp_end !== undefined) ? (
-            <div className="flex items-center gap-1 px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-xs font-mono text-gray-700 dark:text-gray-300">
+            <div className="flex items-center gap-1 px-2 py-1 bg-muted rounded text-xs font-mono text-foreground">
               <Play className="w-3 h-3" />
               {formatTime(hand.video_timestamp_start)} ~ {formatTime(hand.video_timestamp_end)}
             </div>
           ) : hand.timestamp && hand.timestamp !== '00:00' ? (
-            <div className="flex items-center gap-1 px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-xs font-mono text-gray-700 dark:text-gray-300">
+            <div className="flex items-center gap-1 px-2 py-1 bg-muted rounded text-xs font-mono text-foreground">
               <Play className="w-3 h-3" />
               {hand.timestamp}
             </div>
           ) : null}
         </div>
-        <span className="text-xs text-gray-500 dark:text-gray-400">
+        <span className="text-xs text-muted-foreground">
           {hand.created_at && formatDistanceToNow(new Date(hand.created_at), { addSuffix: true })}
         </span>
       </div>
@@ -97,7 +97,7 @@ export const HandListItem = memo(function HandListItem({
 
       {/* Description */}
       {hand.ai_summary && (
-        <p className="text-sm text-gray-700 dark:text-gray-300 mb-3 line-clamp-2">
+        <p className="text-sm text-foreground mb-3 line-clamp-2">
           {hand.ai_summary}
         </p>
       )}
@@ -111,11 +111,11 @@ export const HandListItem = memo(function HandListItem({
               img={hp.player?.photo_url}
               alt={hp.player?.name || 'Player'}
               size="sm"
-              className="ring-2 ring-white dark:ring-gray-800"
+              className="ring-2 ring-card"
             />
           ))}
           {hand.hand_players.length > 5 && (
-            <div className="flex items-center justify-center w-8 h-8 rounded-full bg-gray-200 dark:bg-gray-700 text-xs font-medium text-gray-600 dark:text-gray-300 ring-2 ring-white dark:ring-gray-800">
+            <div className="flex items-center justify-center w-8 h-8 rounded-full bg-muted text-xs font-medium text-muted-foreground ring-2 ring-card">
               +{hand.hand_players.length - 5}
             </div>
           )}
@@ -123,8 +123,8 @@ export const HandListItem = memo(function HandListItem({
       )}
 
       {/* Actions */}
-      <div className="flex items-center justify-between pt-3 border-t border-gray-200 dark:border-gray-700">
-        <div className="flex items-center gap-4 text-sm text-gray-600 dark:text-gray-400">
+      <div className="flex items-center justify-between pt-3 border-t border-border">
+        <div className="flex items-center gap-4 text-sm text-muted-foreground">
           <div className="flex items-center gap-1">
             <Eye className="w-4 h-4" />
             <span>{hand.likes_count || 0}</span>
@@ -141,7 +141,7 @@ export const HandListItem = memo(function HandListItem({
 
         <div className="flex items-center gap-2">
           {hand.pot_river && (
-            <div className="text-sm font-semibold text-gray-900 dark:text-white">
+            <div className="text-sm font-semibold text-foreground">
               Pot: ${(hand.pot_river / 100).toLocaleString()}
             </div>
           )}

--- a/app/(main)/archive/_components/HandsListPanel.tsx
+++ b/app/(main)/archive/_components/HandsListPanel.tsx
@@ -111,10 +111,10 @@ export function HandsListPanel({ streamId, stream }: HandsListPanelProps) {
   }
 
   return (
-    <div className="flex flex-col h-full bg-gray-50 dark:bg-gray-900 w-full">
+    <div className="flex flex-col h-full bg-background w-full">
       {/* YouTube 플레이어 (상단 고정) */}
       {videoId && (
-        <div className="sticky top-0 z-10 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 p-4">
+        <div className="sticky top-0 z-10 bg-card border-b border-border p-4">
           <YouTubePlayer
             ref={playerRef}
             videoId={videoId}
@@ -125,12 +125,12 @@ export function HandsListPanel({ streamId, stream }: HandsListPanelProps) {
       )}
 
       {/* 헤더 + 검색바 */}
-      <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 p-4">
+      <div className="bg-card border-b border-border p-4">
         <div className="flex items-center justify-between mb-3">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+          <h2 className="text-lg font-semibold text-foreground">
             Hand History
             {selectedHand && (
-              <span className="ml-2 text-sm font-normal text-gray-500 dark:text-gray-400">
+              <span className="ml-2 text-sm font-normal text-muted-foreground">
                 - Hand #{selectedHand.number}
               </span>
             )}
@@ -138,17 +138,17 @@ export function HandsListPanel({ streamId, stream }: HandsListPanelProps) {
         </div>
 
         <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 dark:text-gray-500" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <input
             type="text"
             placeholder="플레이어 이름 검색..."
             value={searchQuery}
             onChange={handleSearchChange}
-            className="w-full pl-10 pr-4 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-lg text-sm text-gray-900 dark:text-gray-100 placeholder:text-gray-500 dark:placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-green-400 focus:border-transparent transition-all"
+            className="w-full pl-10 pr-4 py-2 bg-background border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-green-400 focus:border-transparent transition-all"
           />
         </div>
 
-        <div className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+        <div className="mt-2 text-sm text-muted-foreground">
           {filteredHands.length} hands
           {searchQuery && ` (전체 ${hands.length})`}
         </div>
@@ -193,10 +193,10 @@ export function HandsListPanel({ streamId, stream }: HandsListPanelProps) {
 
       {/* 페이지네이션 */}
       {totalPages > 1 && (
-        <div className="bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 p-4">
+        <div className="bg-card border-t border-border p-4">
           <div className="flex items-center justify-center gap-2 flex-wrap">
             <button
-              className="p-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="p-2 bg-card border border-border text-foreground rounded-lg hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))}
               disabled={currentPage === 1}
             >
@@ -214,13 +214,13 @@ export function HandsListPanel({ streamId, stream }: HandsListPanelProps) {
                 return (
                   <div key={page} className="flex items-center gap-2">
                     {showEllipsisBefore && (
-                      <span className="text-gray-400 dark:text-gray-500">...</span>
+                      <span className="text-muted-foreground">...</span>
                     )}
                     <button
                       className={
                         currentPage === page
                           ? "px-4 py-2 bg-green-600 dark:bg-green-700 text-white font-medium rounded-lg text-sm"
-                          : "px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 font-medium rounded-lg text-sm hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                          : "px-4 py-2 bg-card border border-border text-foreground font-medium rounded-lg text-sm hover:bg-accent transition-colors"
                       }
                       onClick={() => setCurrentPage(page)}
                     >
@@ -231,7 +231,7 @@ export function HandsListPanel({ streamId, stream }: HandsListPanelProps) {
               })}
 
             <button
-              className="p-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="p-2 bg-card border border-border text-foreground rounded-lg hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               onClick={() => setCurrentPage(prev => Math.min(totalPages, prev + 1))}
               disabled={currentPage === totalPages}
             >
@@ -239,7 +239,7 @@ export function HandsListPanel({ streamId, stream }: HandsListPanelProps) {
             </button>
           </div>
 
-          <div className="text-center mt-2 text-xs text-gray-500 dark:text-gray-400">
+          <div className="text-center mt-2 text-xs text-muted-foreground">
             Page {currentPage} of {totalPages}
           </div>
         </div>

--- a/app/(main)/archive/_components/MobileArchiveView.tsx
+++ b/app/(main)/archive/_components/MobileArchiveView.tsx
@@ -56,9 +56,9 @@ export function MobileArchiveView({ tournaments, isLoading }: MobileArchiveViewP
         {[1, 2, 3, 4].map((i) => (
           <Card key={i} className="animate-pulse">
             <CardContent className="p-4">
-              <div className="h-5 bg-gray-200 dark:bg-gray-700 rounded w-3/4 mb-3" />
-              <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/2 mb-2" />
-              <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
+              <div className="h-5 bg-muted rounded w-3/4 mb-3" />
+              <div className="h-4 bg-muted rounded w-1/2 mb-2" />
+              <div className="h-4 bg-muted rounded w-1/3" />
             </CardContent>
           </Card>
         ))}

--- a/app/(main)/archive/_components/TournamentCard.tsx
+++ b/app/(main)/archive/_components/TournamentCard.tsx
@@ -26,17 +26,17 @@ export function TournamentCard({ tournament, onClick }: TournamentCardProps) {
   return (
     <button className="block w-full text-left" onClick={onClick}>
       <AnimatedCard>
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 hover:shadow-md transition-all duration-200 cursor-pointer">
+        <div className="bg-card rounded-lg shadow-sm border border-border p-6 hover:shadow-md transition-all duration-200 cursor-pointer">
           {/* Header */}
           <div className="flex items-start gap-4 mb-4">
             {/* Logo */}
             <div className="relative flex-shrink-0">
-              <Avatar className="w-16 h-16 rounded-lg border-2 border-gray-100 dark:border-gray-700">
+              <Avatar className="w-16 h-16 rounded-lg border-2 border-muted">
                 <AvatarImage
                   src={tournament.category_logo_url || `/logos/${tournament.category}.png`}
                   alt={tournament.name}
                 />
-                <AvatarFallback className="text-base font-semibold bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg">
+                <AvatarFallback className="text-base font-semibold bg-muted text-foreground rounded-lg">
                   {tournament.name.split(' ').map(n => n[0]).join('').slice(0, 2).toUpperCase()}
                 </AvatarFallback>
               </Avatar>
@@ -44,12 +44,12 @@ export function TournamentCard({ tournament, onClick }: TournamentCardProps) {
 
             {/* Info */}
             <div className="flex-1 min-w-0">
-              <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 truncate mb-1">
+              <h3 className="text-base font-semibold text-foreground truncate mb-1">
                 {tournament.name}
               </h3>
 
               {/* Category Badge */}
-              <div className="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs font-medium rounded mb-2">
+              <div className="inline-flex items-center gap-1 px-2 py-1 bg-muted text-foreground text-xs font-medium rounded mb-2">
                 <Trophy className="h-3 w-3" />
                 {tournament.category}
               </div>
@@ -59,13 +59,13 @@ export function TournamentCard({ tournament, onClick }: TournamentCardProps) {
           {/* Location & Date */}
           <div className="space-y-1 mb-4">
             {tournament.location && (
-              <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <MapPin className="h-4 w-4 flex-shrink-0" />
                 <span className="truncate">{tournament.location}</span>
               </div>
             )}
             {tournament.start_date && (
-              <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Calendar className="h-4 w-4 flex-shrink-0" />
                 <span>
                   {new Date(tournament.start_date).toLocaleDateString('ko-KR', {
@@ -85,23 +85,23 @@ export function TournamentCard({ tournament, onClick }: TournamentCardProps) {
           </div>
 
           {/* Stats */}
-          <div className="grid grid-cols-3 gap-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+          <div className="grid grid-cols-3 gap-4 pt-4 border-t border-border">
             <div className="space-y-1">
-              <span className="text-xs text-gray-500 dark:text-gray-400 block">Events</span>
-              <span className="text-lg font-semibold text-gray-900 dark:text-gray-100 font-mono">
+              <span className="text-xs text-muted-foreground block">Events</span>
+              <span className="text-lg font-semibold text-foreground font-mono">
                 {eventCount}
               </span>
             </div>
 
             <div className="space-y-1">
-              <span className="text-xs text-gray-500 dark:text-gray-400 block">Streams</span>
-              <span className="text-lg font-semibold text-gray-900 dark:text-gray-100 font-mono">
+              <span className="text-xs text-muted-foreground block">Streams</span>
+              <span className="text-lg font-semibold text-foreground font-mono">
                 {streamCount}
               </span>
             </div>
 
             <div className="space-y-1">
-              <span className="text-xs text-gray-500 dark:text-gray-400 block">Hands</span>
+              <span className="text-xs text-muted-foreground block">Hands</span>
               <span className="text-lg font-semibold text-green-600 dark:text-green-400 font-mono">
                 {handCount}
               </span>

--- a/app/(main)/archive/_components/TournamentListItem.tsx
+++ b/app/(main)/archive/_components/TournamentListItem.tsx
@@ -25,16 +25,16 @@ export function TournamentListItem({ tournament, onClick }: TournamentListItemPr
   return (
     <button className="block w-full text-left" onClick={onClick}>
       <AnimatedCard>
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4 hover:shadow-md hover:border-green-400 dark:hover:border-green-600 transition-all duration-200 cursor-pointer">
+        <div className="bg-card rounded-lg shadow-sm border border-border p-4 hover:shadow-md hover:border-green-400 dark:hover:border-green-600 transition-all duration-200 cursor-pointer">
           <div className="flex items-center gap-4">
             {/* Logo */}
             <div className="relative flex-shrink-0">
-              <Avatar className="w-16 h-16 rounded-lg border-2 border-gray-100 dark:border-gray-700">
+              <Avatar className="w-16 h-16 rounded-lg border-2 border-muted">
                 <AvatarImage
                   src={tournament.category_logo_url || `/logos/${tournament.category}.png`}
                   alt={tournament.name}
                 />
-                <AvatarFallback className="text-base font-semibold bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg">
+                <AvatarFallback className="text-base font-semibold bg-muted text-foreground rounded-lg">
                   {tournament.name.split(' ').map(n => n[0]).join('').slice(0, 2).toUpperCase()}
                 </AvatarFallback>
               </Avatar>
@@ -42,13 +42,13 @@ export function TournamentListItem({ tournament, onClick }: TournamentListItemPr
 
             {/* Tournament Info */}
             <div className="flex-1 min-w-0">
-              <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 truncate mb-1">
+              <h3 className="text-base font-semibold text-foreground truncate mb-1">
                 {tournament.name}
               </h3>
 
-              <div className="flex items-center gap-3 text-sm text-gray-600 dark:text-gray-400 flex-wrap">
+              <div className="flex items-center gap-3 text-sm text-muted-foreground flex-wrap">
                 {/* Category Badge */}
-                <div className="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs font-medium rounded">
+                <div className="inline-flex items-center gap-1 px-2 py-1 bg-muted text-foreground text-xs font-medium rounded">
                   <Trophy className="h-3 w-3" />
                   {tournament.category}
                 </div>
@@ -86,24 +86,24 @@ export function TournamentListItem({ tournament, onClick }: TournamentListItemPr
             {/* Stats */}
             <div className="flex items-center gap-6 flex-shrink-0">
               <div className="text-center">
-                <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Events</div>
-                <div className="text-lg font-semibold text-gray-900 dark:text-gray-100 font-mono">
+                <div className="text-xs text-muted-foreground mb-1">Events</div>
+                <div className="text-lg font-semibold text-foreground font-mono">
                   {eventCount}
                 </div>
               </div>
 
               <div className="text-center">
-                <div className="text-xs text-gray-500 dark:text-gray-400 mb-1 flex items-center gap-1">
+                <div className="text-xs text-muted-foreground mb-1 flex items-center gap-1">
                   <Video className="h-3 w-3" />
                   <span>Streams</span>
                 </div>
-                <div className="text-lg font-semibold text-gray-900 dark:text-gray-100 font-mono">
+                <div className="text-lg font-semibold text-foreground font-mono">
                   {streamCount}
                 </div>
               </div>
 
               <div className="text-center">
-                <div className="text-xs text-gray-500 dark:text-gray-400 mb-1 flex items-center gap-1">
+                <div className="text-xs text-muted-foreground mb-1 flex items-center gap-1">
                   <Hash className="h-3 w-3" />
                   <span>Hands</span>
                 </div>

--- a/app/(main)/archive/cash-game/page.tsx
+++ b/app/(main)/archive/cash-game/page.tsx
@@ -177,12 +177,12 @@ export default function ArchiveCashGamePage() {
         {/* Desktop: 3-column layout */}
         <>
           {/* 1. Left: Filter Sidebar (320px) */}
-          <aside className="hidden lg:block w-80 flex-shrink-0 h-full border-r border-gray-200 dark:border-gray-700">
+          <aside className="hidden lg:block w-80 flex-shrink-0 h-full border-r border-border">
             <ArchiveFilterSidebar {...filterSidebarProps} />
           </aside>
 
           {/* 2. Center: Navigation Sidebar (400px) */}
-          <aside className="hidden lg:block w-[400px] flex-shrink-0 h-full border-r border-gray-200 dark:border-gray-700">
+          <aside className="hidden lg:block w-[400px] flex-shrink-0 h-full border-r border-border">
             <ArchiveNavigationSidebar
               tournaments={filteredTournaments}
               selectedStreamId={selectedStreamId}

--- a/app/(main)/archive/tournament/page.tsx
+++ b/app/(main)/archive/tournament/page.tsx
@@ -159,12 +159,12 @@ export default function ArchiveTournamentPage() {
         {/* Desktop: 3-column layout */}
         <>
           {/* 1. Left: Filter Sidebar (320px) */}
-          <aside className="hidden lg:block w-80 flex-shrink-0 h-full border-r border-gray-200 dark:border-gray-700">
+          <aside className="hidden lg:block w-80 flex-shrink-0 h-full border-r border-border">
             <ArchiveFilterSidebar {...filterSidebarProps} />
           </aside>
 
           {/* 2. Center: Navigation Sidebar (400px) */}
-          <aside className="hidden lg:block w-[400px] flex-shrink-0 h-full border-r border-gray-200 dark:border-gray-700">
+          <aside className="hidden lg:block w-[400px] flex-shrink-0 h-full border-r border-border">
             <ArchiveNavigationSidebar
               tournaments={filteredTournaments}
               selectedStreamId={selectedStreamId}

--- a/app/(main)/community/[id]/page.tsx
+++ b/app/(main)/community/[id]/page.tsx
@@ -17,7 +17,7 @@ const categoryColors: Record<PostCategory, string> = {
   "analysis": "bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300",
   "strategy": "bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300",
   "hand-review": "bg-purple-100 dark:bg-purple-900 text-purple-700 dark:text-purple-300",
-  "general": "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
+  "general": "bg-muted text-foreground"
 }
 
 export default function PostDetailPage() {
@@ -74,7 +74,7 @@ export default function PostDetailPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="min-h-screen bg-background">
         <div className="container max-w-4xl mx-auto py-8 md:py-12 px-4 md:px-6">
           <CardSkeleton count={1} />
         </div>
@@ -84,11 +84,11 @@ export default function PostDetailPage() {
 
   if (!post) {
     return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="min-h-screen bg-background">
         <div className="container max-w-4xl mx-auto py-16 px-4 md:px-6">
-          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-12 text-center">
-            <h2 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Post not found</h2>
-            <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+          <div className="bg-card rounded-lg border p-12 text-center">
+            <h2 className="text-2xl font-semibold text-foreground mb-4">Post not found</h2>
+            <p className="text-sm text-muted-foreground mb-6">
               The post you're looking for doesn't exist or has been removed.
             </p>
             <button className="px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white rounded-md hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors" onClick={() => router.push('/community')}>
@@ -102,18 +102,18 @@ export default function PostDetailPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-background">
       <div className="container max-w-4xl mx-auto py-8 md:py-12 px-4 md:px-6">
         {/* Back Button */}
         <div className="mb-6">
-          <button className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-white dark:hover:bg-gray-800 rounded-md transition-colors" onClick={() => router.push('/community')}>
+          <button className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-foreground hover:bg-accent rounded-md transition-colors" onClick={() => router.push('/community')}>
             <ArrowLeft className="h-4 w-4" />
             Back to community
           </button>
         </div>
 
         {/* Post Card */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6 mb-6">
+        <div className="bg-card rounded-lg border p-6 mb-6">
           {/* Header */}
           <div className="flex items-start gap-4 mb-6">
             <Avatar className="h-12 w-12 rounded-full">
@@ -126,10 +126,10 @@ export default function PostDetailPage() {
             <div className="flex-1 min-w-0">
               <div className="flex items-start justify-between gap-4 mb-2">
                 <div>
-                  <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">
+                  <h3 className="text-base font-semibold text-foreground mb-1">
                     {post.author.name}
                   </h3>
-                  <div className="text-sm text-gray-600 dark:text-gray-400">
+                  <div className="text-sm text-muted-foreground">
                     <span>{new Date(post.createdAt).toLocaleDateString('en-US', {
                       year: 'numeric',
                       month: 'long',
@@ -147,34 +147,34 @@ export default function PostDetailPage() {
           </div>
 
           {/* Title */}
-          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mb-4">{post.title}</h1>
+          <h1 className="text-2xl font-semibold text-foreground mb-4">{post.title}</h1>
 
           {/* Content */}
           <div className="prose prose-sm max-w-none mb-6">
-            <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap leading-normal">
+            <p className="text-sm text-foreground whitespace-pre-wrap leading-normal">
               {post.content}
             </p>
           </div>
 
           {/* Attached Hand */}
           {post.hand && (
-            <div className="mb-6 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+            <div className="mb-6 bg-muted border rounded-lg p-4">
               <div className="flex items-center gap-3">
                 <Link2 className="h-5 w-5 text-blue-600 dark:text-blue-400 flex-shrink-0" />
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1">
                     <span className="text-sm font-mono font-semibold text-blue-600 dark:text-blue-400">#{post.hand.number}</span>
-                    <span className="text-xs text-gray-600 dark:text-gray-400">
+                    <span className="text-xs text-muted-foreground">
                       {post.hand.timestamp}
                     </span>
                   </div>
                   {post.hand.description && (
-                    <p className="text-sm text-gray-700 dark:text-gray-300">{post.hand.description}</p>
+                    <p className="text-sm text-foreground">{post.hand.description}</p>
                   )}
                 </div>
                 <Link
                   href={`/archive?hand=${post.hand.id}`}
-                  className="px-4 py-2 text-sm font-medium bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                  className="px-4 py-2 text-sm font-medium bg-card border text-foreground rounded-md hover:bg-accent transition-colors"
                 >
                   View hand
                 </Link>
@@ -183,10 +183,10 @@ export default function PostDetailPage() {
           )}
 
           {/* Actions */}
-          <div className="flex items-center gap-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+          <div className="flex items-center gap-4 pt-4 border-t border-border">
             <button
               onClick={handleLike}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors focus:ring-2 focus:ring-blue-400"
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium text-foreground hover:bg-accent transition-colors focus:ring-2 focus:ring-blue-400"
             >
               <ThumbsUp className="h-5 w-5" />
               <span className="font-mono">{post.stats.likesCount}</span>
@@ -194,7 +194,7 @@ export default function PostDetailPage() {
 
             <button
               onClick={handleShare}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors focus:ring-2 focus:ring-blue-400"
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium text-foreground hover:bg-accent transition-colors focus:ring-2 focus:ring-blue-400"
             >
               <Share2 className="h-5 w-5" />
               <span>Share</span>

--- a/app/(main)/community/loading.tsx
+++ b/app/(main)/community/loading.tsx
@@ -10,78 +10,78 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card"
  */
 export default function CommunityLoading() {
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-background">
       <div className="container max-w-5xl mx-auto py-8 md:py-12 px-4 md:px-6">
         {/* Page Header */}
         <div className="mb-8 space-y-4">
           <div className="flex items-center justify-between">
-            <Skeleton className="h-10 w-[200px] rounded-lg bg-gray-200 dark:bg-gray-700" />
-            <Skeleton className="h-10 w-[140px] rounded-lg bg-gray-200 dark:bg-gray-700" />
+            <Skeleton className="h-10 w-[200px] rounded-lg bg-muted" />
+            <Skeleton className="h-10 w-[140px] rounded-lg bg-muted" />
           </div>
 
           {/* Tabs Skeleton */}
           <div className="flex gap-2">
-            <Skeleton className="h-10 w-[100px] rounded-lg bg-gray-200 dark:bg-gray-700" />
-            <Skeleton className="h-10 w-[100px] rounded-lg bg-gray-200 dark:bg-gray-700" />
-            <Skeleton className="h-10 w-[100px] rounded-lg bg-gray-200 dark:bg-gray-700" />
+            <Skeleton className="h-10 w-[100px] rounded-lg bg-muted" />
+            <Skeleton className="h-10 w-[100px] rounded-lg bg-muted" />
+            <Skeleton className="h-10 w-[100px] rounded-lg bg-muted" />
           </div>
 
           {/* Search Bar */}
-          <Skeleton className="h-10 w-full rounded-lg bg-gray-200 dark:bg-gray-700" />
+          <Skeleton className="h-10 w-full rounded-lg bg-muted" />
         </div>
 
         {/* Post Cards */}
         <div className="space-y-4">
           {Array.from({ length: 3 }).map((_, i) => (
-            <Card key={i} className="hover:shadow-md transition-shadow rounded-lg border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+            <Card key={i} className="hover:shadow-md transition-shadow rounded-lg border-border bg-card">
               <CardHeader>
                 <div className="flex items-start justify-between">
                   <div className="space-y-2 flex-1">
                     {/* Author Info */}
                     <div className="flex items-center gap-2">
-                      <Skeleton className="h-8 w-8 rounded-full bg-gray-200 dark:bg-gray-700" />
-                      <Skeleton className="h-4 w-[120px] rounded bg-gray-200 dark:bg-gray-700" />
-                      <Skeleton className="h-4 w-[80px] rounded bg-gray-200 dark:bg-gray-700" />
+                      <Skeleton className="h-8 w-8 rounded-full bg-muted" />
+                      <Skeleton className="h-4 w-[120px] rounded bg-muted" />
+                      <Skeleton className="h-4 w-[80px] rounded bg-muted" />
                     </div>
 
                     {/* Title */}
-                    <Skeleton className="h-6 w-[90%] rounded bg-gray-200 dark:bg-gray-700" />
+                    <Skeleton className="h-6 w-[90%] rounded bg-muted" />
                   </div>
 
                   {/* Category Badge */}
-                  <Skeleton className="h-6 w-[80px] rounded-full bg-gray-200 dark:bg-gray-700" />
+                  <Skeleton className="h-6 w-[80px] rounded-full bg-muted" />
                 </div>
               </CardHeader>
 
               <CardContent className="space-y-3">
                 {/* Content */}
                 <div className="space-y-2">
-                  <Skeleton className="h-4 w-full rounded bg-gray-200 dark:bg-gray-700" />
-                  <Skeleton className="h-4 w-[95%] rounded bg-gray-200 dark:bg-gray-700" />
-                  <Skeleton className="h-4 w-[85%] rounded bg-gray-200 dark:bg-gray-700" />
+                  <Skeleton className="h-4 w-full rounded bg-muted" />
+                  <Skeleton className="h-4 w-[95%] rounded bg-muted" />
+                  <Skeleton className="h-4 w-[85%] rounded bg-muted" />
                 </div>
 
                 {/* Attached Hand (optional) */}
                 {i === 0 && (
-                  <div className="border rounded-lg p-3 border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
-                    <Skeleton className="h-4 w-[150px] mb-2 rounded bg-gray-200 dark:bg-gray-700" />
-                    <Skeleton className="h-3 w-[200px] rounded bg-gray-200 dark:bg-gray-700" />
+                  <div className="border rounded-lg p-3 border-border bg-background">
+                    <Skeleton className="h-4 w-[150px] mb-2 rounded bg-muted" />
+                    <Skeleton className="h-3 w-[200px] rounded bg-muted" />
                   </div>
                 )}
 
                 {/* Actions */}
                 <div className="flex items-center gap-4 pt-2">
                   <div className="flex items-center gap-1">
-                    <Skeleton className="h-5 w-5 rounded bg-gray-200 dark:bg-gray-700" />
-                    <Skeleton className="h-4 w-[30px] rounded bg-gray-200 dark:bg-gray-700" />
+                    <Skeleton className="h-5 w-5 rounded bg-muted" />
+                    <Skeleton className="h-4 w-[30px] rounded bg-muted" />
                   </div>
                   <div className="flex items-center gap-1">
-                    <Skeleton className="h-5 w-5 rounded bg-gray-200 dark:bg-gray-700" />
-                    <Skeleton className="h-4 w-[30px] rounded bg-gray-200 dark:bg-gray-700" />
+                    <Skeleton className="h-5 w-5 rounded bg-muted" />
+                    <Skeleton className="h-4 w-[30px] rounded bg-muted" />
                   </div>
                   <div className="flex items-center gap-1">
-                    <Skeleton className="h-5 w-5 rounded bg-gray-200 dark:bg-gray-700" />
-                    <Skeleton className="h-4 w-[30px] rounded bg-gray-200 dark:bg-gray-700" />
+                    <Skeleton className="h-5 w-5 rounded bg-muted" />
+                    <Skeleton className="h-4 w-[30px] rounded bg-muted" />
                   </div>
                 </div>
               </CardContent>

--- a/app/(main)/community/page.tsx
+++ b/app/(main)/community/page.tsx
@@ -43,7 +43,7 @@ const categoryColors: Record<PostCategory, string> = {
   "analysis": "bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300",
   "strategy": "bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300",
   "hand-review": "bg-purple-100 dark:bg-purple-900 text-purple-700 dark:text-purple-300",
-  "general": "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
+  "general": "bg-muted text-foreground"
 }
 
 export default function communityClient() {
@@ -181,7 +181,7 @@ export default function communityClient() {
 
   return (
     <ErrorBoundary>
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="min-h-screen bg-background">
       <main id="main-content" role="main">
         <div className="container max-w-7xl mx-auto py-8 md:py-12 px-4 md:px-6">
         <div className="max-w-4xl mx-auto">
@@ -209,7 +209,7 @@ export default function communityClient() {
             )}
 
             {/* Create Post Button */}
-            <Card className="p-4 dark:bg-gray-800 dark:border-gray-700">
+            <Card className="p-4">
               <Dialog open={isDialogOpen} onOpenChange={(open) => {
                 if (!user && open) {
                   toast.error('Login required')
@@ -225,9 +225,9 @@ export default function communityClient() {
                 </DialogTrigger>
                 <DialogContent className="max-w-2xl">
                   <DialogHeader>
-                    <DialogTitle className="text-gray-900 dark:text-gray-100">Create new post</DialogTitle>
+                    <DialogTitle className="text-foreground">Create new post</DialogTitle>
                   </DialogHeader>
-                  <div className="space-y-4 py-4 bg-white dark:bg-gray-900">
+                  <div className="space-y-4 py-4 bg-card">
                     <div className="space-y-2">
                       <Label htmlFor="title">Title</Label>
                       <Input
@@ -266,13 +266,13 @@ export default function communityClient() {
 
                     {/* Hand Attachment */}
                     <div className="space-y-2">
-                      <Label className="text-gray-900 dark:text-gray-100">Attach hand (optional)</Label>
+                      <Label className="text-foreground">Attach hand (optional)</Label>
                       {selectedHand ? (
-                        <Card className="p-3 relative bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700">
+                        <Card className="p-3 relative bg-card border-border">
                           <Button
                             variant="ghost"
                             size="sm"
-                            className="absolute top-2 right-2 h-6 w-6 p-0 text-gray-900 dark:text-gray-100"
+                            className="absolute top-2 right-2 h-6 w-6 p-0 text-foreground"
                             onClick={() => setSelectedHand(null)}
                           >
                             <X className="h-4 w-4" />
@@ -280,13 +280,13 @@ export default function communityClient() {
                           <div className="pr-8">
                             <div className="flex items-center gap-2 mb-1">
                               <Badge className="bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300">#{selectedHand.number}</Badge>
-                              <Link2 className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                              <Link2 className="h-4 w-4 text-muted-foreground" />
                             </div>
-                            <p className="text-xs text-gray-600 dark:text-gray-400">
+                            <p className="text-xs text-muted-foreground">
                               {selectedHand.tournament} &gt; {selectedHand.day}
                             </p>
                             {selectedHand.description && (
-                              <p className="text-sm text-gray-900 dark:text-gray-100 mt-1 line-clamp-1">{selectedHand.description}</p>
+                              <p className="text-sm text-foreground mt-1 line-clamp-1">{selectedHand.description}</p>
                             )}
                           </div>
                         </Card>
@@ -328,13 +328,13 @@ export default function communityClient() {
 
             {/* Tabs: 모바일 스크롤 */}
             <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as any)}>
-              <div className="flex gap-0 border-b border-gray-200 dark:border-gray-700 overflow-x-auto">
+              <div className="flex gap-0 border-b border-border overflow-x-auto">
                 <button
                   onClick={() => setActiveTab('trending')}
                   className={`px-6 py-3 text-sm font-medium transition-all whitespace-nowrap border-b-2 ${
                     activeTab === 'trending'
                       ? 'border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400'
-                      : 'border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:border-gray-300 dark:hover:border-gray-600'
+                      : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
                   }`}
                 >
                   <TrendingUp className="inline-block h-4 w-4 mr-2" />
@@ -345,7 +345,7 @@ export default function communityClient() {
                   className={`px-6 py-3 text-sm font-medium transition-all whitespace-nowrap border-b-2 ${
                     activeTab === 'recent'
                       ? 'border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400'
-                      : 'border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:border-gray-300 dark:hover:border-gray-600'
+                      : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
                   }`}
                 >
                   <Clock className="inline-block h-4 w-4 mr-2" />
@@ -356,7 +356,7 @@ export default function communityClient() {
                   className={`px-6 py-3 text-sm font-medium transition-all whitespace-nowrap border-b-2 ${
                     activeTab === 'popular'
                       ? 'border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400'
-                      : 'border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:border-gray-300 dark:hover:border-gray-600'
+                      : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
                   }`}
                 >
                   <Star className="inline-block h-4 w-4 mr-2" />
@@ -370,12 +370,12 @@ export default function communityClient() {
                 ) : posts.length === 0 ? (
                   <div className="text-center py-12">
                     <div className="flex justify-center mb-4">
-                      <div className="h-16 w-16 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
-                        <MessageSquare className="h-8 w-8 text-gray-400 dark:text-gray-500" />
+                      <div className="h-16 w-16 rounded-full bg-muted flex items-center justify-center">
+                        <MessageSquare className="h-8 w-8 text-muted-foreground" />
                       </div>
                     </div>
-                    <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">No posts yet</h3>
-                    <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+                    <h3 className="text-lg font-semibold text-foreground mb-2">No posts yet</h3>
+                    <p className="text-sm text-muted-foreground mb-6">
                       Be the first to create a post in the community!
                     </p>
                     <Button onClick={() => setIsDialogOpen(true)}>
@@ -386,7 +386,7 @@ export default function communityClient() {
                   <StaggerContainer staggerDelay={0.1}>
                     {posts.map((post) => (
                       <StaggerItem key={post.id}>
-                        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6 hover:shadow-md transition-all duration-200">
+                        <div className="bg-card rounded-lg border border-border p-6 hover:shadow-md transition-all duration-200">
                           <div className="flex gap-4">
                         <Avatar className="h-12 w-12 rounded-full">
                           <AvatarImage src={post.author.avatarUrl} alt={post.author.name} />
@@ -398,10 +398,10 @@ export default function communityClient() {
                         <div className="flex-1 min-w-0">
                           <div className="flex items-start justify-between gap-4 mb-3">
                             <div className="flex-1">
-                              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">
+                              <h3 className="text-lg font-semibold text-foreground mb-1">
                                 {post.title}
                               </h3>
-                              <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+                              <div className="flex items-center gap-2 text-sm text-muted-foreground">
                                 <span>{post.author.name}</span>
                                 <span>-</span>
                                 <span>{new Date(post.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}</span>
@@ -412,27 +412,27 @@ export default function communityClient() {
                             </Badge>
                           </div>
 
-                          <p className="text-sm text-gray-700 dark:text-gray-300 line-clamp-2 mb-4">
+                          <p className="text-sm text-foreground line-clamp-2 mb-4">
                             {post.content}
                           </p>
 
                           {/* Attached Hand */}
                           {post.hand && (
-                            <div className="mb-4 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-3">
+                            <div className="mb-4 bg-background border border-border rounded-lg p-3">
                               <div className="flex items-center gap-3">
                                 <Link2 className="h-4 w-4 text-blue-600 dark:text-blue-400 flex-shrink-0" />
                                 <div className="flex-1 min-w-0">
                                   <div className="flex items-center gap-2 mb-1">
                                     <span className="text-sm font-mono font-semibold text-blue-600 dark:text-blue-400">#{post.hand.number}</span>
-                                    <span className="text-xs text-gray-600 dark:text-gray-400">{post.hand.timestamp}</span>
+                                    <span className="text-xs text-muted-foreground">{post.hand.timestamp}</span>
                                   </div>
                                   {post.hand.description && (
-                                    <p className="text-xs text-gray-700 dark:text-gray-300 line-clamp-1">{post.hand.description}</p>
+                                    <p className="text-xs text-foreground line-clamp-1">{post.hand.description}</p>
                                   )}
                                 </div>
                                 <Link
                                   href={`/archive?hand=${post.hand.id}`}
-                                  className="px-3 py-1 text-xs font-medium bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                                  className="px-3 py-1 text-xs font-medium bg-card border border-border text-foreground rounded-md hover:bg-muted transition-colors"
                                 >
                                   View
                                 </Link>
@@ -440,16 +440,16 @@ export default function communityClient() {
                             </div>
                           )}
 
-                          <div className="flex items-center gap-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+                          <div className="flex items-center gap-4 pt-4 border-t border-border">
                             <button
                               onClick={() => handleLike(post.id)}
-                              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors focus:ring-2 focus:ring-blue-400"
+                              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium text-foreground hover:bg-muted transition-colors focus:ring-2 focus:ring-blue-400"
                             >
                               <ThumbsUp className="w-4 h-4" />
                               <span className="font-mono">{post.stats.likesCount}</span>
                             </button>
 
-                            <Link href={`/community/${post.id}`} className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors focus:ring-2 focus:ring-blue-400">
+                            <Link href={`/community/${post.id}`} className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium text-foreground hover:bg-muted transition-colors focus:ring-2 focus:ring-blue-400">
                               <MessageSquare className="w-4 h-4" />
                               <span className="font-mono">{post.stats.commentsCount}</span>
                             </Link>

--- a/app/(main)/error.tsx
+++ b/app/(main)/error.tsx
@@ -16,17 +16,17 @@ export default function Error({
   }, [error])
 
   return (
-    <main className="min-h-screen bg-gray-900 flex items-center justify-center px-4">
+    <main className="min-h-screen bg-background flex items-center justify-center px-4">
       <div className="max-w-md w-full text-center space-y-6">
         <div className="inline-flex items-center justify-center w-16 h-16 bg-red-500/10 rounded-full mb-4">
           <AlertTriangle className="w-8 h-8 text-red-500" />
         </div>
 
         <div className="space-y-2">
-          <h1 className="text-2xl font-bold text-gray-50">
+          <h1 className="text-2xl font-bold text-foreground">
             페이지 로딩 실패
           </h1>
-          <p className="text-gray-400">
+          <p className="text-muted-foreground">
             일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.
           </p>
         </div>
@@ -40,14 +40,14 @@ export default function Error({
           </button>
           <Link
             href="/"
-            className="px-6 py-3 bg-gray-800 text-gray-50 font-semibold rounded-lg hover:bg-gray-700 transition-colors border border-gray-700"
+            className="px-6 py-3 bg-muted text-foreground font-semibold rounded-lg hover:bg-muted/80 transition-colors border border-border"
           >
             홈으로 이동
           </Link>
         </div>
 
         {error.digest && (
-          <p className="text-sm text-gray-600 font-mono">
+          <p className="text-sm text-muted-foreground font-mono">
             Error ID: {error.digest}
           </p>
         )}

--- a/app/(main)/loading.tsx
+++ b/app/(main)/loading.tsx
@@ -1,34 +1,34 @@
 export default function Loading() {
   return (
-    <main className="min-h-screen bg-gray-900">
+    <main className="min-h-screen bg-background">
       {/* Hero Skeleton */}
       <section className="relative py-20 md:py-32 overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-b from-gray-800/50 to-gray-900" />
+        <div className="absolute inset-0 bg-gradient-to-b from-muted/50 to-background" />
         <div className="container max-w-7xl mx-auto px-4 md:px-6 relative z-10">
           <div className="flex flex-col items-center text-center space-y-8">
-            <div className="h-20 w-3/4 bg-gray-800 rounded-lg animate-pulse" />
-            <div className="h-6 w-1/2 bg-gray-800 rounded-lg animate-pulse" />
+            <div className="h-20 w-3/4 bg-muted rounded-lg animate-pulse" />
+            <div className="h-6 w-1/2 bg-muted rounded-lg animate-pulse" />
             <div className="flex gap-4">
-              <div className="h-12 w-48 bg-gray-800 rounded-lg animate-pulse" />
-              <div className="h-12 w-48 bg-gray-800 rounded-lg animate-pulse" />
+              <div className="h-12 w-48 bg-muted rounded-lg animate-pulse" />
+              <div className="h-12 w-48 bg-muted rounded-lg animate-pulse" />
             </div>
           </div>
         </div>
       </section>
 
       {/* Stats Skeleton */}
-      <section className="py-12 md:py-16 bg-gray-800">
+      <section className="py-12 md:py-16 bg-muted">
         <div className="container max-w-7xl mx-auto px-4 md:px-6">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {[1, 2, 3].map((i) => (
               <div
                 key={i}
-                className="bg-gray-900 border border-gray-700 rounded-lg p-8"
+                className="bg-background border border-border rounded-lg p-8"
               >
                 <div className="flex flex-col items-center gap-4">
-                  <div className="w-16 h-16 bg-gray-800 rounded-full animate-pulse" />
-                  <div className="h-10 w-24 bg-gray-800 rounded-lg animate-pulse" />
-                  <div className="h-4 w-32 bg-gray-800 rounded-lg animate-pulse" />
+                  <div className="w-16 h-16 bg-muted rounded-full animate-pulse" />
+                  <div className="h-10 w-24 bg-muted rounded-lg animate-pulse" />
+                  <div className="h-4 w-32 bg-muted rounded-lg animate-pulse" />
                 </div>
               </div>
             ))}
@@ -37,23 +37,23 @@ export default function Loading() {
       </section>
 
       {/* Highlights Skeleton */}
-      <section className="py-12 md:py-16 bg-gray-900">
+      <section className="py-12 md:py-16 bg-background">
         <div className="container max-w-7xl mx-auto px-4 md:px-6">
           <div className="mb-8">
-            <div className="h-8 w-48 bg-gray-800 rounded-lg animate-pulse mb-2" />
-            <div className="h-4 w-64 bg-gray-800 rounded-lg animate-pulse" />
+            <div className="h-8 w-48 bg-muted rounded-lg animate-pulse mb-2" />
+            <div className="h-4 w-64 bg-muted rounded-lg animate-pulse" />
           </div>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {[1, 2, 3].map((i) => (
               <div
                 key={i}
-                className="bg-gray-800 border border-gray-700 rounded-lg overflow-hidden"
+                className="bg-muted border border-border rounded-lg overflow-hidden"
               >
-                <div className="aspect-video bg-gray-700 animate-pulse" />
+                <div className="aspect-video bg-border animate-pulse" />
                 <div className="p-6 space-y-4">
-                  <div className="h-4 w-3/4 bg-gray-700 rounded animate-pulse" />
-                  <div className="h-4 w-full bg-gray-700 rounded animate-pulse" />
-                  <div className="h-10 w-full bg-gray-700 rounded animate-pulse" />
+                  <div className="h-4 w-3/4 bg-border rounded animate-pulse" />
+                  <div className="h-4 w-full bg-border rounded animate-pulse" />
+                  <div className="h-10 w-full bg-border rounded animate-pulse" />
                 </div>
               </div>
             ))}

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -15,7 +15,7 @@ export default async function HomePage() {
   ])
 
   return (
-    <main className="min-h-screen bg-gray-900">
+    <main className="min-h-screen bg-background">
       <HeroSection />
       <StatsSection stats={stats} />
       <HighlightsSection highlights={highlights} />

--- a/app/(main)/players/[id]/page.tsx
+++ b/app/(main)/players/[id]/page.tsx
@@ -241,9 +241,9 @@ export default function PlayerDetailClient() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="min-h-screen bg-background">
         <div className="container max-w-7xl mx-auto py-16 text-center">
-          <p className="text-base text-gray-600 dark:text-gray-400">Loading...</p>
+          <p className="text-base text-muted-foreground">Loading...</p>
         </div>
       </div>
     )
@@ -251,9 +251,9 @@ export default function PlayerDetailClient() {
 
   if (!player) {
     return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="min-h-screen bg-background">
         <div className="container max-w-7xl mx-auto py-16 text-center">
-          <p className="text-base text-gray-600 dark:text-gray-400">Player not found</p>
+          <p className="text-base text-muted-foreground">Player not found</p>
           <button
             className="mt-4 px-4 py-2 bg-green-600 dark:bg-green-700 text-white font-medium rounded-lg hover:bg-green-700 dark:hover:bg-green-600 transition-colors inline-flex items-center gap-2"
             onClick={() => router.push('/players')}
@@ -267,11 +267,11 @@ export default function PlayerDetailClient() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-background">
       <div className="container max-w-7xl mx-auto py-8 md:py-12 px-4 md:px-6">
         <div className="mb-6">
           <button
-            className="px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors inline-flex items-center gap-2"
+            className="px-4 py-2 bg-card border border-border text-foreground font-medium rounded-lg hover:bg-muted transition-colors inline-flex items-center gap-2"
             onClick={() => router.push('/players')}
           >
             <ArrowLeft className="h-4 w-4" />
@@ -280,14 +280,14 @@ export default function PlayerDetailClient() {
         </div>
 
         {/* Player Profile Header */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 md:p-8 mb-8">
+        <div className="bg-card rounded-lg shadow-sm border border-border p-6 md:p-8 mb-8">
           <div className="grid grid-cols-1 md:grid-cols-[auto_1fr] gap-6 md:gap-8">
             {/* Large Profile Image: 모바일 중앙 정렬 */}
             <div className="flex flex-col items-center md:items-start">
               <div className="relative">
-                <Avatar className="w-32 h-32 rounded-full border-4 border-gray-100 dark:border-gray-700">
+                <Avatar className="w-32 h-32 rounded-full border-4 border-muted">
                   <AvatarImage src={player.photo_url} alt={player.name} />
-                  <AvatarFallback className="text-3xl font-semibold bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+                  <AvatarFallback className="text-3xl font-semibold bg-muted text-foreground">
                     {player.name.split(' ').map(n => n[0]).join('')}
                   </AvatarFallback>
                 </Avatar>
@@ -301,7 +301,7 @@ export default function PlayerDetailClient() {
                       onChange={handlePhotoUpload}
                     />
                     <button
-                      className="absolute -bottom-2 left-1/2 -translate-x-1/2 px-2 py-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 text-xs font-medium rounded hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                      className="absolute -bottom-2 left-1/2 -translate-x-1/2 px-2 py-1 bg-card border border-border text-foreground text-xs font-medium rounded hover:bg-muted transition-colors"
                       onClick={() => fileInputRef.current?.click()}
                       disabled={updatePhotoMutation.isPending}
                     >
@@ -316,10 +316,10 @@ export default function PlayerDetailClient() {
             <div className="space-y-6">
               {/* Name & Meta */}
               <div>
-                <h1 className="text-3xl font-semibold text-gray-900 dark:text-gray-100 mb-2">{player.name}</h1>
+                <h1 className="text-3xl font-semibold text-foreground mb-2">{player.name}</h1>
                 <div className="flex gap-3 items-center flex-wrap">
                   {player.country && (
-                    <div className="inline-flex items-center gap-2 px-3 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-sm font-medium rounded-lg">
+                    <div className="inline-flex items-center gap-2 px-3 py-1 bg-muted text-foreground text-sm font-medium rounded-lg">
                       <span className="text-lg">{getCountryFlag(player.country)}</span>
                       {player.country}
                     </div>
@@ -347,29 +347,29 @@ export default function PlayerDetailClient() {
               {/* Stats Grid - 모바일 2x2, 데스크톱 4x1 */}
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-6">
                 <div className="space-y-1">
-                  <span className="text-xs text-gray-500 dark:text-gray-400 block">Total Hands</span>
-                  <span className="text-2xl font-semibold text-gray-900 dark:text-gray-100 font-mono">
+                  <span className="text-xs text-muted-foreground block">Total Hands</span>
+                  <span className="text-2xl font-semibold text-foreground font-mono">
                     {totalHandsCount}
                   </span>
                 </div>
 
                 <div className="space-y-1">
-                  <span className="text-xs text-gray-500 dark:text-gray-400 block">Winnings</span>
+                  <span className="text-xs text-muted-foreground block">Winnings</span>
                   <span className="text-2xl font-semibold text-green-600 dark:text-green-400 font-mono">
                     {formatWinnings(player.total_winnings)}
                   </span>
                 </div>
 
                 <div className="space-y-1">
-                  <span className="text-xs text-gray-500 dark:text-gray-400 block">Tournaments</span>
-                  <span className="text-2xl font-semibold text-gray-900 dark:text-gray-100 font-mono">
+                  <span className="text-xs text-muted-foreground block">Tournaments</span>
+                  <span className="text-2xl font-semibold text-foreground font-mono">
                     {statistics.tournamentsCount}
                   </span>
                 </div>
 
                 <div className="space-y-1">
-                  <span className="text-xs text-gray-500 dark:text-gray-400 block">Events</span>
-                  <span className="text-2xl font-semibold text-gray-900 dark:text-gray-100 font-mono">
+                  <span className="text-xs text-muted-foreground block">Events</span>
+                  <span className="text-2xl font-semibold text-foreground font-mono">
                     {statistics.eventsCount}
                   </span>
                 </div>
@@ -391,15 +391,15 @@ export default function PlayerDetailClient() {
         </div>
 
         {/* Tabs */}
-        <div className="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
-          <div className="flex gap-0 border-b border-gray-200 dark:border-gray-700">
+        <div className="mb-6 bg-card rounded-lg shadow-sm border border-border">
+          <div className="flex gap-0 border-b border-border">
             <button className="px-6 py-3 text-sm font-medium text-green-600 dark:text-green-400 border-b-2 border-green-600 dark:border-green-400 bg-green-50 dark:bg-green-900/20">
               핸드 히스토리
             </button>
-            <button className="px-6 py-3 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
+            <button className="px-6 py-3 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-accent transition-colors">
               토너먼트
             </button>
-            <button className="px-6 py-3 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
+            <button className="px-6 py-3 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-accent transition-colors">
               통계
             </button>
           </div>
@@ -420,15 +420,15 @@ export default function PlayerDetailClient() {
           {totalHandsCount > 0 && (
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
               {/* Prize History Chart */}
-              <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">상금 히스토리</h3>
+              <div className="bg-card rounded-lg shadow-sm border border-border p-6">
+                <h3 className="text-lg font-semibold text-foreground mb-4">상금 히스토리</h3>
                 <PrizeHistoryChart data={prizeHistory} />
               </div>
 
               {/* Pie Chart - Tournament Categories */}
               {statistics.tournamentCategories.length > 0 && (
-                <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">토너먼트 카테고리 분포</h3>
+                <div className="bg-card rounded-lg shadow-sm border border-border p-6">
+                  <h3 className="text-lg font-semibold text-foreground mb-4">토너먼트 카테고리 분포</h3>
                   <TournamentCategoryChart data={statistics.tournamentCategories} />
                 </div>
               )}
@@ -437,15 +437,15 @@ export default function PlayerDetailClient() {
         </div>
 
         {/* Hands List - Hierarchical */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 mt-6">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
+        <div className="bg-card rounded-lg shadow-sm border border-border p-6 mt-6">
+          <h2 className="text-xl font-semibold text-foreground mb-4">
             핸드 히스토리
-            <span className="font-mono ml-2 text-gray-600 dark:text-gray-400">({totalHandsCount})</span>
+            <span className="font-mono ml-2 text-muted-foreground">({totalHandsCount})</span>
           </h2>
           <ScrollArea className="h-[calc(100vh-480px)]">
             {tournaments.length === 0 ? (
               <div className="text-center py-12">
-                <p className="text-base text-gray-600 dark:text-gray-400">
+                <p className="text-base text-muted-foreground">
                   이 플레이어의 핸드가 없습니다
                 </p>
               </div>
@@ -455,7 +455,7 @@ export default function PlayerDetailClient() {
                   <div key={tournament.id}>
                     {/* Tournament Level */}
                     <div
-                      className="flex items-center gap-3 py-3 px-4 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors cursor-pointer border-b border-gray-200 dark:border-gray-700"
+                      className="flex items-center gap-3 py-3 px-4 hover:bg-accent transition-colors cursor-pointer border-b border-border"
                       onClick={() => toggleTournament(tournament.id)}
                     >
                       {tournament.expanded ? (
@@ -466,7 +466,7 @@ export default function PlayerDetailClient() {
                       <div className="flex h-6 w-6 items-center justify-center bg-green-600 dark:bg-green-700 text-xs font-bold text-white rounded flex-shrink-0">
                         {tournament.category.charAt(0)}
                       </div>
-                      <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                      <span className="text-sm font-semibold text-foreground">
                         {tournament.name}
                       </span>
                     </div>
@@ -477,7 +477,7 @@ export default function PlayerDetailClient() {
                         {tournament.events?.map((event) => (
                           <div key={event.id}>
                             <div
-                              className="flex items-center gap-3 py-2 px-4 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors cursor-pointer border-b border-gray-100 dark:border-gray-700"
+                              className="flex items-center gap-3 py-2 px-4 hover:bg-accent transition-colors cursor-pointer border-b border-border"
                               onClick={() => toggleEvent(tournament.id, event.id)}
                             >
                               {event.expanded ? (
@@ -485,10 +485,10 @@ export default function PlayerDetailClient() {
                               ) : (
                                 <ChevronRight className="h-4 w-4 text-green-500 dark:text-green-400" />
                               )}
-                              <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                              <span className="text-sm font-medium text-foreground">
                                 {event.name}
                               </span>
-                              <div className="ml-auto inline-flex items-center px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-xs font-medium rounded">
+                              <div className="ml-auto inline-flex items-center px-2 py-1 bg-muted text-foreground text-xs font-medium rounded">
                                 {event.days.reduce((total, day) => total + day.hands.length, 0)} hands
                               </div>
                             </div>
@@ -498,11 +498,11 @@ export default function PlayerDetailClient() {
                               <div className="ml-8 mt-2">
                                 {event.days?.map((day) => (
                                   <div key={day.id} className="mb-4">
-                                    <div className="flex items-center gap-2 py-2 px-3 mb-2 bg-gray-50 dark:bg-gray-700 rounded">
-                                      <span className="text-xs font-semibold text-gray-700 dark:text-gray-300 font-mono">
+                                    <div className="flex items-center gap-2 py-2 px-3 mb-2 bg-muted rounded">
+                                      <span className="text-xs font-semibold text-foreground font-mono">
                                         {day.name}
                                       </span>
-                                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                                      <span className="text-xs text-muted-foreground">
                                         ({day.hands.length} hands)
                                       </span>
                                     </div>

--- a/app/(main)/players/_components/PlayerDetailPanel.tsx
+++ b/app/(main)/players/_components/PlayerDetailPanel.tsx
@@ -350,15 +350,15 @@ export function PlayerDetailPanel({ player }: PlayerDetailPanelProps) {
             {totalHandsCount > 0 && (
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                 {/* Prize History Chart */}
-                <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">상금 히스토리</h3>
+                <div className="bg-card rounded-lg shadow-sm border border-border p-6">
+                  <h3 className="text-lg font-semibold text-foreground mb-4">상금 히스토리</h3>
                   <PrizeHistoryChart data={prizeHistory} />
                 </div>
 
                 {/* Tournament Categories */}
                 {statistics.tournamentCategories.length > 0 && (
-                  <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-                    <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">토너먼트 카테고리 분포</h3>
+                  <div className="bg-card rounded-lg shadow-sm border border-border p-6">
+                    <h3 className="text-lg font-semibold text-foreground mb-4">토너먼트 카테고리 분포</h3>
                     <TournamentCategoryChart data={statistics.tournamentCategories} />
                   </div>
                 )}
@@ -367,14 +367,14 @@ export function PlayerDetailPanel({ player }: PlayerDetailPanelProps) {
           </div>
 
           {/* Hands List */}
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-            <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
+          <div className="bg-card rounded-lg shadow-sm border border-border p-6">
+            <h2 className="text-xl font-semibold text-foreground mb-4">
               핸드 히스토리
-              <span className="font-mono ml-2 text-gray-600 dark:text-gray-400">({totalHandsCount})</span>
+              <span className="font-mono ml-2 text-muted-foreground">({totalHandsCount})</span>
             </h2>
             {tournaments.length === 0 ? (
               <div className="text-center py-12">
-                <p className="text-base text-gray-600 dark:text-gray-400">
+                <p className="text-base text-muted-foreground">
                   이 플레이어의 핸드가 없습니다
                 </p>
               </div>
@@ -384,7 +384,7 @@ export function PlayerDetailPanel({ player }: PlayerDetailPanelProps) {
                   <div key={tournament.id}>
                     {/* Tournament Level */}
                     <div
-                      className="flex items-center gap-3 py-3 px-4 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors cursor-pointer border-b border-gray-200 dark:border-gray-700"
+                      className="flex items-center gap-3 py-3 px-4 hover:bg-accent transition-colors cursor-pointer border-b border-border"
                       onClick={() => toggleTournament(tournament.id)}
                     >
                       {tournament.expanded ? (
@@ -395,7 +395,7 @@ export function PlayerDetailPanel({ player }: PlayerDetailPanelProps) {
                       <div className="flex h-6 w-6 items-center justify-center bg-green-600 dark:bg-green-700 text-xs font-bold text-white rounded flex-shrink-0">
                         {tournament.category.charAt(0)}
                       </div>
-                      <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                      <span className="text-sm font-semibold text-foreground">
                         {tournament.name}
                       </span>
                     </div>
@@ -406,7 +406,7 @@ export function PlayerDetailPanel({ player }: PlayerDetailPanelProps) {
                         {tournament.events?.map((event: any) => (
                           <div key={event.id}>
                             <div
-                              className="flex items-center gap-3 py-2 px-4 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors cursor-pointer border-b border-gray-100 dark:border-gray-700"
+                              className="flex items-center gap-3 py-2 px-4 hover:bg-accent transition-colors cursor-pointer border-b border-border"
                               onClick={() => toggleSubEvent(tournament.id, event.id)}
                             >
                               {event.expanded ? (
@@ -414,10 +414,10 @@ export function PlayerDetailPanel({ player }: PlayerDetailPanelProps) {
                               ) : (
                                 <ChevronRight className="h-4 w-4 text-green-500 dark:text-green-400" />
                               )}
-                              <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                              <span className="text-sm font-medium text-foreground">
                                 {event.name}
                               </span>
-                              <div className="ml-auto inline-flex items-center px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-xs font-medium rounded">
+                              <div className="ml-auto inline-flex items-center px-2 py-1 bg-muted text-foreground text-xs font-medium rounded">
                                 {event.days.reduce((total: number, day: any) => total + day.hands.length, 0)} hands
                               </div>
                             </div>
@@ -427,11 +427,11 @@ export function PlayerDetailPanel({ player }: PlayerDetailPanelProps) {
                               <div className="ml-8 mt-2">
                                 {event.days?.map((day: any) => (
                                   <div key={day.id} className="mb-4">
-                                    <div className="flex items-center gap-2 py-2 px-3 mb-2 bg-gray-50 dark:bg-gray-700 rounded">
-                                      <span className="text-xs font-semibold text-gray-700 dark:text-gray-300 font-mono">
+                                    <div className="flex items-center gap-2 py-2 px-3 mb-2 bg-muted rounded">
+                                      <span className="text-xs font-semibold text-foreground font-mono">
                                         {day.name}
                                       </span>
-                                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                                      <span className="text-xs text-muted-foreground">
                                         ({day.hands.length} hands)
                                       </span>
                                     </div>

--- a/app/(main)/players/_components/PlayerDetailPanel.tsx
+++ b/app/(main)/players/_components/PlayerDetailPanel.tsx
@@ -201,11 +201,11 @@ export function PlayerDetailPanel({ player }: PlayerDetailPanelProps) {
   }
 
   return (
-    <div className="flex flex-col h-full bg-gray-50 dark:bg-gray-900">
+    <div className="flex flex-col h-full bg-background">
       {/* Header with Back Button - Fixed at top */}
-      <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 p-4 md:p-6 flex items-center justify-between">
+      <div className="bg-card border-b border-border p-4 md:p-6 flex items-center justify-between">
         <button
-          className="px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors inline-flex items-center gap-2"
+          className="px-4 py-2 bg-card border border-border text-foreground font-medium rounded-lg hover:bg-muted transition-colors inline-flex items-center gap-2"
           onClick={handleBack}
         >
           <ArrowLeft className="h-4 w-4" />
@@ -213,7 +213,7 @@ export function PlayerDetailPanel({ player }: PlayerDetailPanelProps) {
         </button>
 
         <button
-          className="p-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+          className="p-2 text-muted-foreground hover:text-foreground transition-colors"
           onClick={handleBack}
           title="Close"
         >
@@ -225,14 +225,14 @@ export function PlayerDetailPanel({ player }: PlayerDetailPanelProps) {
       <div className="flex-1 overflow-y-auto">
         <div className="p-4 md:p-6 space-y-6">
           {/* Player Profile Header */}
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+          <div className="bg-card rounded-lg shadow-sm border border-border p-6">
             <div className="grid grid-cols-1 md:grid-cols-[auto_1fr] gap-6">
               {/* Profile Image */}
               <div className="flex flex-col items-center md:items-start">
                 <div className="relative">
-                  <Avatar className="w-32 h-32 rounded-full border-4 border-gray-100 dark:border-gray-700">
+                  <Avatar className="w-32 h-32 rounded-full border-4 border-muted">
                     <AvatarImage src={player.photo_url} alt={player.name} />
-                    <AvatarFallback className="text-3xl font-semibold bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+                    <AvatarFallback className="text-3xl font-semibold bg-muted text-foreground">
                       {player.name.split(' ').map(n => n[0]).join('')}
                     </AvatarFallback>
                   </Avatar>
@@ -246,7 +246,7 @@ export function PlayerDetailPanel({ player }: PlayerDetailPanelProps) {
                         onChange={handlePhotoUpload}
                       />
                       <button
-                        className="absolute -bottom-2 left-1/2 -translate-x-1/2 px-2 py-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 text-xs font-medium rounded hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                        className="absolute -bottom-2 left-1/2 -translate-x-1/2 px-2 py-1 bg-card border border-border text-foreground text-xs font-medium rounded hover:bg-muted transition-colors"
                         onClick={() => fileInputRef.current?.click()}
                         disabled={updatePhotoMutation.isPending}
                       >
@@ -261,10 +261,10 @@ export function PlayerDetailPanel({ player }: PlayerDetailPanelProps) {
               <div className="space-y-4">
                 {/* Name & Meta */}
                 <div>
-                  <h1 className="text-2xl md:text-3xl font-semibold text-gray-900 dark:text-gray-100 mb-2">{player.name}</h1>
+                  <h1 className="text-2xl md:text-3xl font-semibold text-foreground mb-2">{player.name}</h1>
                   <div className="flex gap-2 items-center flex-wrap">
                     {player.country && (
-                      <div className="inline-flex items-center gap-2 px-3 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-sm font-medium rounded-lg">
+                      <div className="inline-flex items-center gap-2 px-3 py-1 bg-muted text-foreground text-sm font-medium rounded-lg">
                         <span className="text-lg">{getCountryFlag(player.country)}</span>
                         {player.country}
                       </div>
@@ -292,29 +292,29 @@ export function PlayerDetailPanel({ player }: PlayerDetailPanelProps) {
                 {/* Stats Grid */}
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                   <div className="space-y-1">
-                    <span className="text-xs text-gray-500 dark:text-gray-400 block">Total Hands</span>
-                    <span className="text-xl font-semibold text-gray-900 dark:text-gray-100 font-mono">
+                    <span className="text-xs text-muted-foreground block">Total Hands</span>
+                    <span className="text-xl font-semibold text-foreground font-mono">
                       {totalHandsCount}
                     </span>
                   </div>
 
                   <div className="space-y-1">
-                    <span className="text-xs text-gray-500 dark:text-gray-400 block">Winnings</span>
+                    <span className="text-xs text-muted-foreground block">Winnings</span>
                     <span className="text-xl font-semibold text-green-600 dark:text-green-400 font-mono">
                       {formatWinnings(player.total_winnings)}
                     </span>
                   </div>
 
                   <div className="space-y-1">
-                    <span className="text-xs text-gray-500 dark:text-gray-400 block">Tournaments</span>
-                    <span className="text-xl font-semibold text-gray-900 dark:text-gray-100 font-mono">
+                    <span className="text-xs text-muted-foreground block">Tournaments</span>
+                    <span className="text-xl font-semibold text-foreground font-mono">
                       {statistics.tournamentsCount}
                     </span>
                   </div>
 
                   <div className="space-y-1">
-                    <span className="text-xs text-gray-500 dark:text-gray-400 block">Events</span>
-                    <span className="text-xl font-semibold text-gray-900 dark:text-gray-100 font-mono">
+                    <span className="text-xs text-muted-foreground block">Events</span>
+                    <span className="text-xl font-semibold text-foreground font-mono">
                       {statistics.eventsCount}
                     </span>
                   </div>

--- a/app/(main)/players/_components/PlayersMainPanel.tsx
+++ b/app/(main)/players/_components/PlayersMainPanel.tsx
@@ -73,23 +73,23 @@ export function PlayersMainPanel({ players, loading }: PlayersMainPanelProps) {
   }
 
   return (
-    <div className="flex flex-col h-full bg-gray-50 dark:bg-gray-900">
+    <div className="flex flex-col h-full bg-background">
       {/* Search Bar - Fixed at top */}
-      <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 p-4 md:p-6">
+      <div className="bg-card border-b border-border p-4 md:p-6">
         <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 dark:text-gray-500" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <input
             type="text"
             placeholder="플레이어 검색..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-lg text-sm text-gray-900 dark:text-gray-100 placeholder:text-gray-500 dark:placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-green-400 focus:border-transparent transition-all"
+            className="w-full pl-10 pr-4 py-2 bg-background border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-green-400 focus:border-transparent transition-all"
           />
         </div>
 
         {/* Results Count */}
-        <div className="mt-3 text-sm text-gray-600 dark:text-gray-400">
-          <span className="font-semibold text-gray-900 dark:text-gray-100">
+        <div className="mt-3 text-sm text-muted-foreground">
+          <span className="font-semibold text-foreground">
             {startIndex + 1}-{Math.min(endIndex, filteredPlayers.length)}
           </span>
           {' '}/ {filteredPlayers.length} 플레이어
@@ -107,14 +107,14 @@ export function PlayersMainPanel({ players, loading }: PlayersMainPanelProps) {
                   className="block w-full text-left"
                 >
                   <AnimatedCard>
-                    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 hover:shadow-md transition-all duration-200 cursor-pointer">
+                    <div className="bg-card rounded-lg shadow-sm border border-border p-6 hover:shadow-md transition-all duration-200 cursor-pointer">
                       {/* Player Header */}
                       <div className="flex items-start gap-4 mb-4">
                         {/* Profile Image */}
                         <div className="relative flex-shrink-0">
-                          <Avatar className="w-16 h-16 rounded-full border-2 border-gray-100 dark:border-gray-700">
+                          <Avatar className="w-16 h-16 rounded-full border-2 border-muted">
                             <AvatarImage src={player.photo_url} alt={player.name} />
-                            <AvatarFallback className="text-base font-semibold bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+                            <AvatarFallback className="text-base font-semibold bg-muted text-foreground">
                               {player.name.split(' ').map(n => n[0]).join('')}
                             </AvatarFallback>
                           </Avatar>
@@ -122,13 +122,13 @@ export function PlayersMainPanel({ players, loading }: PlayersMainPanelProps) {
 
                         {/* Player Info */}
                         <div className="flex-1 min-w-0">
-                          <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 truncate mb-1">
+                          <h3 className="text-base font-semibold text-foreground truncate mb-1">
                             {player.name}
                           </h3>
 
                           {/* Country */}
                           {player.country && (
-                            <div className="inline-flex items-center px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs font-medium rounded">
+                            <div className="inline-flex items-center px-2 py-1 bg-muted text-foreground text-xs font-medium rounded">
                               {player.country}
                             </div>
                           )}
@@ -136,16 +136,16 @@ export function PlayersMainPanel({ players, loading }: PlayersMainPanelProps) {
                       </div>
 
                       {/* Player Stats */}
-                      <div className="grid grid-cols-2 gap-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+                      <div className="grid grid-cols-2 gap-4 pt-4 border-t border-border">
                         <div className="space-y-1">
-                          <span className="text-xs text-gray-500 dark:text-gray-400 block">Total Hands</span>
-                          <span className="text-lg font-semibold text-gray-900 dark:text-gray-100 font-mono">
+                          <span className="text-xs text-muted-foreground block">Total Hands</span>
+                          <span className="text-lg font-semibold text-foreground font-mono">
                             {player.hand_count}
                           </span>
                         </div>
 
                         <div className="space-y-1">
-                          <span className="text-xs text-gray-500 dark:text-gray-400 block">Winnings</span>
+                          <span className="text-xs text-muted-foreground block">Winnings</span>
                           <span className="text-lg font-semibold text-green-600 dark:text-green-400 font-mono">
                             {formatWinnings(player.total_winnings)}
                           </span>
@@ -171,10 +171,10 @@ export function PlayersMainPanel({ players, loading }: PlayersMainPanelProps) {
 
       {/* Pagination - Fixed at bottom */}
       {totalPages > 1 && (
-        <div className="bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 p-4">
+        <div className="bg-card border-t border-border p-4">
           <div className="flex items-center justify-center gap-2 flex-wrap">
             <button
-              className="p-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="p-2 bg-card border border-border text-foreground rounded-lg hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))}
               disabled={currentPage === 1}
             >
@@ -191,11 +191,11 @@ export function PlayersMainPanel({ players, loading }: PlayersMainPanelProps) {
                 const showEllipsisBefore = index > 0 && page - arr[index - 1] > 1
                 return (
                   <div key={page} className="flex items-center gap-2">
-                    {showEllipsisBefore && <span className="text-gray-400 dark:text-gray-500">...</span>}
+                    {showEllipsisBefore && <span className="text-muted-foreground">...</span>}
                     <button
                       className={currentPage === page
                         ? "px-4 py-2 bg-green-600 dark:bg-green-700 text-white font-medium rounded-lg text-sm"
-                        : "px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 font-medium rounded-lg text-sm hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                        : "px-4 py-2 bg-card border border-border text-foreground font-medium rounded-lg text-sm hover:bg-muted transition-colors"
                       }
                       onClick={() => setCurrentPage(page)}
                     >
@@ -206,7 +206,7 @@ export function PlayersMainPanel({ players, loading }: PlayersMainPanelProps) {
               })}
 
             <button
-              className="p-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="p-2 bg-card border border-border text-foreground rounded-lg hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               onClick={() => setCurrentPage(prev => Math.min(totalPages, prev + 1))}
               disabled={currentPage === totalPages}
             >

--- a/app/(main)/players/_components/PlayersPageLayout.tsx
+++ b/app/(main)/players/_components/PlayersPageLayout.tsx
@@ -80,7 +80,7 @@ export function PlayersPageLayout({ players, loading }: PlayersPageLayoutProps) 
       {/* Main Content */}
       <main className="flex-1 overflow-hidden flex flex-col">
         {/* Mobile Menu Button */}
-        <div className="lg:hidden bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 p-4">
+        <div className="lg:hidden bg-card border-b border-border p-4">
           <Sheet open={isMobileMenuOpen} onOpenChange={setIsMobileMenuOpen}>
             <SheetTrigger asChild>
               <Button

--- a/app/(main)/players/_components/PlayersSidebar.tsx
+++ b/app/(main)/players/_components/PlayersSidebar.tsx
@@ -52,11 +52,11 @@ export function PlayersSidebar({
   ]
 
   return (
-    <div className="flex flex-col h-full bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700">
+    <div className="flex flex-col h-full bg-card border-r border-border">
       {/* Header */}
-      <div className="p-4 border-b border-gray-200 dark:border-gray-700">
-        <h2 className="font-semibold text-lg text-gray-900 dark:text-gray-100">Leaderboards</h2>
-        <p className="text-sm text-gray-600 dark:text-gray-400">
+      <div className="p-4 border-b border-border">
+        <h2 className="font-semibold text-lg text-foreground">Leaderboards</h2>
+        <p className="text-sm text-muted-foreground">
           플레이어 순위 및 통계
         </p>
       </div>
@@ -65,7 +65,7 @@ export function PlayersSidebar({
         <div className="p-4 space-y-6">
           {/* Leaderboard Menu */}
           <div>
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-3">Rankings</h3>
+            <h3 className="text-sm font-medium text-foreground mb-3">Rankings</h3>
             <div className="space-y-2">
               {leaderboards.map((board) => {
                 const Icon = board.icon
@@ -83,26 +83,26 @@ export function PlayersSidebar({
                     className={`w-full flex items-start gap-3 p-3 rounded-lg transition-all ${
                       isSelected
                         ? 'bg-green-50 dark:bg-green-900/20 border-2 border-green-500 dark:border-green-600'
-                        : 'bg-gray-50 dark:bg-gray-700/50 border-2 border-transparent hover:border-gray-300 dark:hover:border-gray-600'
+                        : 'bg-muted/50 border-2 border-transparent hover:border-border'
                     }`}
                   >
                     <Icon className={`h-5 w-5 mt-0.5 flex-shrink-0 ${
                       isSelected
                         ? 'text-green-600 dark:text-green-400'
-                        : 'text-gray-500 dark:text-gray-400'
+                        : 'text-muted-foreground'
                     }`} />
                     <div className="flex-1 text-left">
                       <div className={`text-sm font-medium ${
                         isSelected
                           ? 'text-green-900 dark:text-green-100'
-                          : 'text-gray-900 dark:text-gray-100'
+                          : 'text-foreground'
                       }`}>
                         {board.label}
                       </div>
                       <div className={`text-xs ${
                         isSelected
                           ? 'text-green-700 dark:text-green-300'
-                          : 'text-gray-500 dark:text-gray-400'
+                          : 'text-muted-foreground'
                       }`}>
                         {board.description}
                       </div>
@@ -113,7 +113,7 @@ export function PlayersSidebar({
             </div>
           </div>
 
-          <Separator className="bg-gray-200 dark:bg-gray-700" />
+          <Separator className="bg-border" />
 
           {/* Country Leaderboard Accordion */}
           <div>
@@ -127,36 +127,36 @@ export function PlayersSidebar({
               className={`w-full flex items-center justify-between p-3 rounded-lg transition-all ${
                 selectedLeaderboard === 'country'
                   ? 'bg-green-50 dark:bg-green-900/20 border-2 border-green-500 dark:border-green-600'
-                  : 'bg-gray-50 dark:bg-gray-700/50 border-2 border-transparent hover:border-gray-300 dark:hover:border-gray-600'
+                  : 'bg-muted/50 border-2 border-transparent hover:border-border'
               }`}
             >
               <div className="flex items-center gap-3">
                 <Globe className={`h-5 w-5 ${
                   selectedLeaderboard === 'country'
                     ? 'text-green-600 dark:text-green-400'
-                    : 'text-gray-500 dark:text-gray-400'
+                    : 'text-muted-foreground'
                 }`} />
                 <div className="text-left">
                   <div className={`text-sm font-medium ${
                     selectedLeaderboard === 'country'
                       ? 'text-green-900 dark:text-green-100'
-                      : 'text-gray-900 dark:text-gray-100'
+                      : 'text-foreground'
                   }`}>
                     Country Leaderboard
                   </div>
                   <div className={`text-xs ${
                     selectedLeaderboard === 'country'
                       ? 'text-green-700 dark:text-green-300'
-                      : 'text-gray-500 dark:text-gray-400'
+                      : 'text-muted-foreground'
                   }`}>
                     국가별 순위
                   </div>
                 </div>
               </div>
               {isCountryExpanded ? (
-                <ChevronDown className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
               ) : (
-                <ChevronRight className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
               )}
             </button>
 
@@ -177,7 +177,7 @@ export function PlayersSidebar({
                       className={`w-full flex items-center justify-between p-2 rounded-md text-sm transition-colors ${
                         isSelected
                           ? 'bg-green-100 dark:bg-green-900/30 text-green-900 dark:text-green-100'
-                          : 'hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300'
+                          : 'hover:bg-accent text-foreground'
                       }`}
                     >
                       <span className="truncate">{country}</span>
@@ -186,7 +186,7 @@ export function PlayersSidebar({
                         className={`ml-2 ${
                           isSelected
                             ? 'bg-green-600 dark:bg-green-700'
-                            : 'bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300'
+                            : 'bg-muted text-foreground'
                         }`}
                       >
                         {count}
@@ -200,13 +200,13 @@ export function PlayersSidebar({
         </div>
       </ScrollArea>
 
-      <Separator className="bg-gray-200 dark:bg-gray-700" />
+      <Separator className="bg-border" />
 
       {/* Footer Actions */}
       <div className="p-4">
         <Button
           variant="ghost"
-          className="w-full rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300"
+          className="w-full rounded-lg hover:bg-muted text-foreground"
           onClick={onReset}
         >
           <RotateCcw className="h-4 w-4 mr-2" />

--- a/app/(main)/search/_components/HandDetailPanel.tsx
+++ b/app/(main)/search/_components/HandDetailPanel.tsx
@@ -80,7 +80,7 @@ export function HandDetailPanel({ handId }: HandDetailPanelProps) {
 
   if (isLoading) {
     return (
-      <div className="flex-1 flex items-center justify-center bg-gray-50 dark:bg-gray-900">
+      <div className="flex-1 flex items-center justify-center bg-background">
         <Loader2 className="w-8 h-8 animate-spin text-green-600 dark:text-green-400" />
       </div>
     )
@@ -88,7 +88,7 @@ export function HandDetailPanel({ handId }: HandDetailPanelProps) {
 
   if (error) {
     return (
-      <div className="flex-1 flex items-center justify-center bg-gray-50 dark:bg-gray-900 p-8">
+      <div className="flex-1 flex items-center justify-center bg-background p-8">
         <EmptyState
           icon={Search}
           title="핸드를 불러올 수 없습니다"
@@ -101,7 +101,7 @@ export function HandDetailPanel({ handId }: HandDetailPanelProps) {
 
   if (!hand) {
     return (
-      <div className="flex-1 flex items-center justify-center bg-gray-50 dark:bg-gray-900 p-8">
+      <div className="flex-1 flex items-center justify-center bg-background p-8">
         <EmptyState
           icon={Search}
           title="핸드를 찾을 수 없습니다"
@@ -117,11 +117,11 @@ export function HandDetailPanel({ handId }: HandDetailPanelProps) {
   const videoId = extractVideoId(stream?.video_url)
 
   return (
-    <div className="flex-1 overflow-auto bg-gray-50 dark:bg-gray-900 p-6">
+    <div className="flex-1 overflow-auto bg-background p-6">
       <div className="max-w-4xl mx-auto space-y-6">
         {/* YouTube Player (상단 고정) */}
         {videoId && (
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border sticky top-0 z-10">
+          <div className="bg-card rounded-lg p-6 border sticky top-0 z-10">
             <h2 className="text-lg font-semibold mb-4">영상</h2>
             <YouTubePlayer
               videoId={videoId}
@@ -131,7 +131,7 @@ export function HandDetailPanel({ handId }: HandDetailPanelProps) {
           </div>
         )}
         {/* Header */}
-        <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border">
+        <div className="bg-card rounded-lg p-6 border">
           <div className="flex items-center justify-between">
             <h1 className="text-2xl font-bold">Hand #{hand.number}</h1>
             <Link
@@ -142,7 +142,7 @@ export function HandDetailPanel({ handId }: HandDetailPanelProps) {
               <ExternalLink className="w-4 h-4" />
             </Link>
           </div>
-          <div className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+          <div className="mt-2 text-sm text-muted-foreground">
             {tournament?.name}
             {stream?.name && ` • ${stream.name}`}
             {hand.stakes && ` • ${hand.stakes}`}
@@ -166,7 +166,7 @@ export function HandDetailPanel({ handId }: HandDetailPanelProps) {
 
         {/* Board Cards */}
         {(hand.board_flop || hand.board_turn || hand.board_river) && (
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border">
+          <div className="bg-card rounded-lg p-6 border">
             <h2 className="text-lg font-semibold mb-4">보드</h2>
             <div className="flex gap-2 flex-wrap">
               {/* Flop */}
@@ -195,13 +195,13 @@ export function HandDetailPanel({ handId }: HandDetailPanelProps) {
 
         {/* Players */}
         {hand.hand_players && hand.hand_players.length > 0 && (
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border">
+          <div className="bg-card rounded-lg p-6 border">
             <h2 className="text-lg font-semibold mb-4">플레이어</h2>
             <div className="space-y-3">
               {hand.hand_players.map((hp: any) => (
                 <div
                   key={hp.id}
-                  className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-900 rounded"
+                  className="flex items-center justify-between p-3 bg-muted rounded"
                 >
                   <div className="flex items-center gap-3">
                     <Avatar className="w-10 h-10">
@@ -210,7 +210,7 @@ export function HandDetailPanel({ handId }: HandDetailPanelProps) {
                     </Avatar>
                     <div>
                       <div className="font-medium">{hp.player?.name}</div>
-                      <div className="text-xs text-gray-500">
+                      <div className="text-xs text-muted-foreground">
                         {hp.poker_position || "Position N/A"}
                       </div>
                     </div>
@@ -242,7 +242,7 @@ export function HandDetailPanel({ handId }: HandDetailPanelProps) {
 
         {/* Actions Timeline */}
         {hand.hand_actions && hand.hand_actions.length > 0 && (
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border">
+          <div className="bg-card rounded-lg p-6 border">
             <h2 className="text-lg font-semibold mb-4">액션 타임라인</h2>
             <div className="space-y-2">
               {hand.hand_actions
@@ -250,11 +250,11 @@ export function HandDetailPanel({ handId }: HandDetailPanelProps) {
                 .map((action: any) => (
                   <div
                     key={action.id}
-                    className="flex items-center gap-3 p-2 bg-gray-50 dark:bg-gray-900 rounded"
+                    className="flex items-center gap-3 p-2 bg-muted rounded"
                   >
-                    <div className="text-xs text-gray-500 w-16 uppercase">{action.street}</div>
+                    <div className="text-xs text-muted-foreground w-16 uppercase">{action.street}</div>
                     <div className="font-medium flex-1">{action.player_name}</div>
-                    <div className="text-sm text-gray-600 dark:text-gray-400 capitalize">
+                    <div className="text-sm text-muted-foreground capitalize">
                       {action.action_type}
                     </div>
                     {action.amount > 0 && (

--- a/app/(main)/search/_components/HandDetailPanel.tsx
+++ b/app/(main)/search/_components/HandDetailPanel.tsx
@@ -50,7 +50,7 @@ function Card({ card }: CardProps) {
     <div
       className={cn(
         "w-12 h-16 rounded border-2 bg-white flex flex-col items-center justify-center font-bold shadow-sm",
-        isRed ? "text-red-600 border-red-300" : "text-gray-900 border-gray-300"
+        isRed ? "text-red-600 border-red-300" : "text-foreground border-border"
       )}
     >
       <div className="text-lg">{rank}</div>

--- a/app/(main)/search/_components/HandValueDialog.tsx
+++ b/app/(main)/search/_components/HandValueDialog.tsx
@@ -165,25 +165,25 @@ export function HandValueDialog({ open, onOpenChange, onSelect }: HandValueDialo
                 "w-full h-auto py-3 px-4 justify-between",
                 selectedHandType === handType.name
                   ? "border-green-500 bg-green-600/10 hover:bg-green-600/20"
-                  : "border-gray-600 bg-gray-800 hover:bg-gray-700"
+                  : "border-border bg-muted hover:bg-accent"
               )}
               onClick={() => setSelectedHandType(handType.name)}
             >
-              <span className="text-sm font-semibold text-gray-200">
+              <span className="text-sm font-semibold text-foreground">
                 {handType.name}
               </span>
               <div className="flex gap-1">
                 {handType.cards.map((card, idx) => (
                   <div
                     key={idx}
-                    className="w-10 h-14 bg-white rounded flex flex-col items-center justify-center border border-gray-300"
+                    className="w-10 h-14 bg-white rounded flex flex-col items-center justify-center border border-border"
                   >
                     <div
                       className={cn(
                         "text-lg font-bold",
                         card.color === 'red' && "text-red-600",
                         card.color === 'black' && "text-black",
-                        card.color === 'gray' && "text-gray-400"
+                        card.color === 'gray' && "text-muted-foreground"
                       )}
                     >
                       {card.rank}
@@ -207,8 +207,8 @@ export function HandValueDialog({ open, onOpenChange, onSelect }: HandValueDialo
         </div>
 
         {/* Match Type Selection */}
-        <div className="space-y-2 pt-4 border-t border-gray-700">
-          <div className="text-sm text-gray-400 mb-2">Match Type</div>
+        <div className="space-y-2 pt-4 border-t border-border">
+          <div className="text-sm text-muted-foreground mb-2">Match Type</div>
           <div className="grid grid-cols-3 gap-2">
             {matchTypes.map((type) => (
               <Button
@@ -219,7 +219,7 @@ export function HandValueDialog({ open, onOpenChange, onSelect }: HandValueDialo
                   "text-xs",
                   matchType === type
                     ? "border-green-500 bg-green-600 hover:bg-green-600 text-white"
-                    : "border-gray-600 bg-gray-800 hover:bg-gray-700 text-gray-300"
+                    : "border-border bg-muted hover:bg-accent text-foreground"
                 )}
                 onClick={() => setMatchType(type)}
               >

--- a/app/(main)/search/_components/HoleCardDialog.tsx
+++ b/app/(main)/search/_components/HoleCardDialog.tsx
@@ -48,7 +48,7 @@ export function HoleCardDialog({ open, onOpenChange, onSelect }: HoleCardDialogP
         <div className="space-y-4">
           {/* Card 1 Selection */}
           <div className="space-y-2">
-            <Label className="text-sm text-gray-300">Card 1</Label>
+            <Label className="text-sm text-foreground">Card 1</Label>
             <div className="grid grid-cols-7 gap-2">
               {RANKS.map((rank) => (
                 <Button
@@ -59,7 +59,7 @@ export function HoleCardDialog({ open, onOpenChange, onSelect }: HoleCardDialogP
                     "h-10 w-full text-sm font-semibold",
                     card1 === rank
                       ? "border-green-500 bg-green-600 hover:bg-green-600 text-white"
-                      : "border-gray-600 bg-gray-800 hover:bg-gray-700 text-gray-300"
+                      : "border-border bg-muted hover:bg-accent text-foreground"
                   )}
                   onClick={() => setCard1(rank)}
                 >
@@ -71,7 +71,7 @@ export function HoleCardDialog({ open, onOpenChange, onSelect }: HoleCardDialogP
 
           {/* Card 2 Selection */}
           <div className="space-y-2">
-            <Label className="text-sm text-gray-300">Card 2</Label>
+            <Label className="text-sm text-foreground">Card 2</Label>
             <div className="grid grid-cols-7 gap-2">
               {RANKS.map((rank) => (
                 <Button
@@ -82,7 +82,7 @@ export function HoleCardDialog({ open, onOpenChange, onSelect }: HoleCardDialogP
                     "h-10 w-full text-sm font-semibold",
                     card2 === rank
                       ? "border-green-500 bg-green-600 hover:bg-green-600 text-white"
-                      : "border-gray-600 bg-gray-800 hover:bg-gray-700 text-gray-300"
+                      : "border-border bg-muted hover:bg-accent text-foreground"
                   )}
                   onClick={() => setCard2(rank)}
                 >
@@ -101,7 +101,7 @@ export function HoleCardDialog({ open, onOpenChange, onSelect }: HoleCardDialogP
             />
             <label
               htmlFor="suited"
-              className="text-sm font-medium text-gray-300 cursor-pointer"
+              className="text-sm font-medium text-foreground cursor-pointer"
             >
               Suited only
             </label>

--- a/app/(main)/search/_components/SearchFilterSidebar.tsx
+++ b/app/(main)/search/_components/SearchFilterSidebar.tsx
@@ -183,7 +183,7 @@ export function SearchFilterSidebar({ onApplyFilters }: SearchFilterSidebarProps
   }
 
   return (
-    <div className="flex flex-col h-full bg-white dark:bg-gray-800 border-r">
+    <div className="flex flex-col h-full bg-background border-r">
       {/* Header */}
       <div className="p-4 border-b">
         <h2 className="text-lg font-semibold">검색 필터</h2>
@@ -353,7 +353,7 @@ export function SearchFilterSidebar({ onApplyFilters }: SearchFilterSidebarProps
                     }
                   />
                 </div>
-                <div className="flex items-center justify-between text-xs text-gray-600 dark:text-gray-400">
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
                   <span>${(filters.smallBlindRange[0] / 100).toLocaleString()}</span>
                   <span>${(filters.smallBlindRange[1] / 100).toLocaleString()}</span>
                 </div>
@@ -373,7 +373,7 @@ export function SearchFilterSidebar({ onApplyFilters }: SearchFilterSidebarProps
                     }
                   />
                 </div>
-                <div className="flex items-center justify-between text-xs text-gray-600 dark:text-gray-400">
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
                   <span>${(filters.bigBlindRange[0] / 100).toLocaleString()}</span>
                   <span>${(filters.bigBlindRange[1] / 100).toLocaleString()}</span>
                 </div>
@@ -636,7 +636,7 @@ export function SearchFilterSidebar({ onApplyFilters }: SearchFilterSidebarProps
                     }
                   />
                 </div>
-                <div className="flex items-center justify-between text-xs text-gray-600 dark:text-gray-400">
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
                   <span>${(filters.stackRange[0] / 100).toLocaleString()}</span>
                   <span>${(filters.stackRange[1] / 100).toLocaleString()}</span>
                 </div>
@@ -705,7 +705,7 @@ export function SearchFilterSidebar({ onApplyFilters }: SearchFilterSidebarProps
                     }
                   />
                 </div>
-                <div className="flex items-center justify-between text-xs text-gray-600 dark:text-gray-400">
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
                   <span>${(filters.potSizeRange[0] / 100).toLocaleString()}</span>
                   <span>${(filters.potSizeRange[1] / 100).toLocaleString()}</span>
                 </div>
@@ -766,7 +766,7 @@ export function SearchFilterSidebar({ onApplyFilters }: SearchFilterSidebarProps
       </div>
 
       {/* Footer Buttons */}
-      <div className="p-4 border-t space-y-2 bg-white dark:bg-gray-800">
+      <div className="p-4 border-t space-y-2 bg-background">
         <Button onClick={applyFilters} className="w-full" size="lg">
           필터 적용
         </Button>

--- a/app/(main)/search/_components/SearchResultsList.tsx
+++ b/app/(main)/search/_components/SearchResultsList.tsx
@@ -30,11 +30,11 @@ export function SearchResultsList({
   onHandSelect,
 }: SearchResultsListProps) {
   return (
-    <div className="flex flex-col h-full bg-white dark:bg-gray-800">
+    <div className="flex flex-col h-full bg-background">
       {/* Header */}
       <div className="p-4 border-b">
         <h2 className="text-lg font-semibold">검색 결과</h2>
-        <div className="text-sm text-gray-600 dark:text-gray-400">
+        <div className="text-sm text-muted-foreground">
           {loading ? "검색 중..." : `${hands.length}개의 핸드 발견`}
         </div>
       </div>
@@ -64,7 +64,7 @@ export function SearchResultsList({
                   "w-full p-3 text-left rounded-md border transition-colors",
                   selectedHandId === hand.id
                     ? "border-green-400 bg-green-50 dark:bg-green-900/20"
-                    : "border-gray-200 dark:border-gray-700 hover:border-green-300 dark:hover:border-green-600"
+                    : "border-border hover:border-green-300 dark:hover:border-green-600"
                 )}
               >
                 {/* Hand Number & Pot */}
@@ -79,7 +79,7 @@ export function SearchResultsList({
 
                 {/* Tournament & Day */}
                 {(hand.tournament_name || hand.day_name) && (
-                  <div className="text-sm text-gray-600 dark:text-gray-400 mb-2">
+                  <div className="text-sm text-muted-foreground mb-2">
                     {hand.tournament_name}
                     {hand.tournament_name && hand.day_name && " • "}
                     {hand.day_name}
@@ -88,7 +88,7 @@ export function SearchResultsList({
 
                 {/* Description */}
                 {hand.description && (
-                  <div className="text-sm text-gray-700 dark:text-gray-300 mb-2 line-clamp-2">
+                  <div className="text-sm text-foreground mb-2 line-clamp-2">
                     {hand.description}
                   </div>
                 )}
@@ -99,13 +99,13 @@ export function SearchResultsList({
                     {hand.player_names.slice(0, 3).map((name, i) => (
                       <span
                         key={i}
-                        className="px-2 py-0.5 bg-gray-100 dark:bg-gray-700 rounded text-xs"
+                        className="px-2 py-0.5 bg-muted rounded text-xs"
                       >
                         {name}
                       </span>
                     ))}
                     {hand.player_names.length > 3 && (
-                      <span className="px-2 py-0.5 bg-gray-100 dark:bg-gray-700 rounded text-xs">
+                      <span className="px-2 py-0.5 bg-muted rounded text-xs">
                         +{hand.player_names.length - 3}
                       </span>
                     )}

--- a/app/admin/kan/history/page.tsx
+++ b/app/admin/kan/history/page.tsx
@@ -16,7 +16,7 @@ export default function HistoryPage() {
     <div className="container mx-auto py-8 px-4 max-w-7xl">
       <div className="mb-8">
         <div className="flex items-center gap-3 mb-2">
-          <History className="h-8 w-8 text-gray-500" />
+          <History className="h-8 w-8 text-muted-foreground" />
           <h1 className="text-3xl font-bold">분석 기록</h1>
         </div>
         <p className="text-muted-foreground">

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -305,7 +305,7 @@ export default function UsersClient() {
                           targetUser.role === "high_templar" ? "bg-purple-700 text-white" :
                           targetUser.role === "arbiter" ? "bg-blue-700 text-white" :
                           targetUser.role === "templar" ? "bg-green-700 text-white" :
-                          "bg-gray-700 text-white"
+                          "bg-muted text-foreground"
                         }`}>
                           {targetUser.role === "admin" ? "ADMIN" :
                            targetUser.role === "high_templar" ? "HIGH TEMPLAR" :
@@ -331,13 +331,13 @@ export default function UsersClient() {
                             new Date().getTime() - new Date((targetUser as any).last_sign_in_at).getTime() < 7 * 24 * 60 * 60 * 1000
                               ? "text-green-400"
                               : new Date().getTime() - new Date((targetUser as any).last_sign_in_at).getTime() > 30 * 24 * 60 * 60 * 1000
-                              ? "text-gray-600"
+                              ? "text-muted-foreground"
                               : ""
                           }>
                             LAST SIGN IN: {new Date((targetUser as any).last_sign_in_at).toLocaleDateString("ko-KR")}
                           </span>
                         ) : (
-                          <span className="text-gray-600">LAST SIGN IN: NEVER</span>
+                          <span className="text-muted-foreground">LAST SIGN IN: NEVER</span>
                         )}
                       </div>
                       {targetUser.is_banned && targetUser.ban_reason && (

--- a/app/globals.css
+++ b/app/globals.css
@@ -45,32 +45,32 @@
   --red-500: #EF4444;    /* Error */
   --red-600: #DC2626;
 
-  /* === SEMANTIC COLORS (DARK MODE ONLY) === */
-  --background: var(--gray-900);
-  --foreground: var(--gray-50);
-  --muted: var(--gray-800);
-  --muted-foreground: var(--gray-400);
-  --border: var(--gray-700);
-  --input: var(--gray-700);
-  --primary: var(--gold-400);
-  --primary-foreground: var(--gray-900);
-  --accent: var(--gray-800);
-  --accent-foreground: var(--gold-300);
+  /* === SEMANTIC COLORS (LIGHT MODE DEFAULT) === */
+  --background: #FFFFFF;
+  --foreground: var(--gray-900);
+  --muted: var(--gray-100);
+  --muted-foreground: var(--gray-500);
+  --border: var(--gray-200);
+  --input: var(--gray-200);
+  --primary: var(--gold-600);
+  --primary-foreground: #FFFFFF;
+  --accent: var(--gold-100);
+  --accent-foreground: var(--gold-700);
   --destructive: var(--red-500);
   --destructive-foreground: white;
-  --ring: var(--gold-400);
+  --ring: var(--gold-500);
 
   /* Card */
-  --card: var(--gray-900);
-  --card-foreground: var(--gray-50);
+  --card: #FFFFFF;
+  --card-foreground: var(--gray-900);
 
   /* Popover */
-  --popover: var(--gray-800);
-  --popover-foreground: var(--gray-50);
+  --popover: #FFFFFF;
+  --popover-foreground: var(--gray-900);
 
   /* Secondary */
-  --secondary: var(--gray-800);
-  --secondary-foreground: var(--gray-50);
+  --secondary: var(--gray-100);
+  --secondary-foreground: var(--gray-900);
 
   /* Chart Colors */
   --chart-1: var(--gold-400);
@@ -80,14 +80,14 @@
   --chart-5: #F472B6;
 
   /* Sidebar */
-  --sidebar: var(--gray-900);
-  --sidebar-foreground: var(--gray-300);
-  --sidebar-primary: var(--gold-400);
-  --sidebar-primary-foreground: var(--gray-900);
-  --sidebar-accent: var(--gray-800);
-  --sidebar-accent-foreground: var(--gray-50);
-  --sidebar-border: var(--gray-700);
-  --sidebar-ring: var(--gold-400);
+  --sidebar: var(--gray-50);
+  --sidebar-foreground: var(--gray-600);
+  --sidebar-primary: var(--gold-600);
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: var(--gold-100);
+  --sidebar-accent-foreground: var(--gray-900);
+  --sidebar-border: var(--gray-200);
+  --sidebar-ring: var(--gold-500);
 
   /* === TYPOGRAPHY === */
   --font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -154,7 +154,44 @@
   --shadow-xl: 0 20px 25px rgba(0, 0, 0, 0.1), 0 10px 10px rgba(0, 0, 0, 0.04);
 }
 
-/* Dark mode class removed - dark mode is now the only theme */
+/* === DARK MODE === */
+.dark {
+  --background: var(--gray-900);
+  --foreground: var(--gray-50);
+  --muted: var(--gray-800);
+  --muted-foreground: var(--gray-400);
+  --border: var(--gray-700);
+  --input: var(--gray-700);
+  --primary: var(--gold-400);
+  --primary-foreground: var(--gray-900);
+  --accent: var(--gray-800);
+  --accent-foreground: var(--gold-300);
+  --destructive: var(--red-500);
+  --destructive-foreground: white;
+  --ring: var(--gold-400);
+
+  /* Card */
+  --card: var(--gray-900);
+  --card-foreground: var(--gray-50);
+
+  /* Popover */
+  --popover: var(--gray-800);
+  --popover-foreground: var(--gray-50);
+
+  /* Secondary */
+  --secondary: var(--gray-800);
+  --secondary-foreground: var(--gray-50);
+
+  /* Sidebar */
+  --sidebar: var(--gray-900);
+  --sidebar-foreground: var(--gray-300);
+  --sidebar-primary: var(--gold-400);
+  --sidebar-primary-foreground: var(--gray-900);
+  --sidebar-accent: var(--gray-800);
+  --sidebar-accent-foreground: var(--gray-50);
+  --sidebar-border: var(--gray-700);
+  --sidebar-ring: var(--gold-400);
+}
 
 /* ============================================
    2. TAILWIND THEME INLINE

--- a/app/legal/cookies/page.tsx
+++ b/app/legal/cookies/page.tsx
@@ -39,29 +39,29 @@ export default function CookiePolicyPage() {
           <p>
             These cookies are necessary for the Service to function and cannot be disabled:
           </p>
-          <table className="w-full border-collapse border border-gray-300 dark:border-gray-700 my-4">
+          <table className="w-full border-collapse border border-border my-4">
             <thead>
               <tr className="bg-muted">
-                <th className="border border-gray-300 dark:border-gray-700 p-2">Cookie Name</th>
-                <th className="border border-gray-300 dark:border-gray-700 p-2">Purpose</th>
-                <th className="border border-gray-300 dark:border-gray-700 p-2">Duration</th>
+                <th className="border border-border p-2">Cookie Name</th>
+                <th className="border border-border p-2">Purpose</th>
+                <th className="border border-border p-2">Duration</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td className="border border-gray-300 dark:border-gray-700 p-2"><code>firebase-auth-token</code></td>
-                <td className="border border-gray-300 dark:border-gray-700 p-2">Authentication (Firebase)</td>
-                <td className="border border-gray-300 dark:border-gray-700 p-2">Session</td>
+                <td className="border border-border p-2"><code>firebase-auth-token</code></td>
+                <td className="border border-border p-2">Authentication (Firebase)</td>
+                <td className="border border-border p-2">Session</td>
               </tr>
               <tr>
-                <td className="border border-gray-300 dark:border-gray-700 p-2"><code>firebase-refresh-token</code></td>
-                <td className="border border-gray-300 dark:border-gray-700 p-2">Session persistence</td>
-                <td className="border border-gray-300 dark:border-gray-700 p-2">30 days</td>
+                <td className="border border-border p-2"><code>firebase-refresh-token</code></td>
+                <td className="border border-border p-2">Session persistence</td>
+                <td className="border border-border p-2">30 days</td>
               </tr>
               <tr>
-                <td className="border border-gray-300 dark:border-gray-700 p-2"><code>theme</code></td>
-                <td className="border border-gray-300 dark:border-gray-700 p-2">Dark/Light mode preference</td>
-                <td className="border border-gray-300 dark:border-gray-700 p-2">1 year</td>
+                <td className="border border-border p-2"><code>theme</code></td>
+                <td className="border border-border p-2">Dark/Light mode preference</td>
+                <td className="border border-border p-2">1 year</td>
               </tr>
             </tbody>
           </table>
@@ -70,24 +70,24 @@ export default function CookiePolicyPage() {
           <p>
             These cookies help us understand how visitors use our Service:
           </p>
-          <table className="w-full border-collapse border border-gray-300 dark:border-gray-700 my-4">
+          <table className="w-full border-collapse border border-border my-4">
             <thead>
               <tr className="bg-muted">
-                <th className="border border-gray-300 dark:border-gray-700 p-2">Provider</th>
-                <th className="border border-gray-300 dark:border-gray-700 p-2">Purpose</th>
-                <th className="border border-gray-300 dark:border-gray-700 p-2">Duration</th>
+                <th className="border border-border p-2">Provider</th>
+                <th className="border border-border p-2">Purpose</th>
+                <th className="border border-border p-2">Duration</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td className="border border-gray-300 dark:border-gray-700 p-2">Vercel Analytics</td>
-                <td className="border border-gray-300 dark:border-gray-700 p-2">Page views, performance metrics</td>
-                <td className="border border-gray-300 dark:border-gray-700 p-2">Session</td>
+                <td className="border border-border p-2">Vercel Analytics</td>
+                <td className="border border-border p-2">Page views, performance metrics</td>
+                <td className="border border-border p-2">Session</td>
               </tr>
               <tr>
-                <td className="border border-gray-300 dark:border-gray-700 p-2">Vercel Speed Insights</td>
-                <td className="border border-gray-300 dark:border-gray-700 p-2">Core Web Vitals monitoring</td>
-                <td className="border border-gray-300 dark:border-gray-700 p-2">Session</td>
+                <td className="border border-border p-2">Vercel Speed Insights</td>
+                <td className="border border-border p-2">Core Web Vitals monitoring</td>
+                <td className="border border-border p-2">Session</td>
               </tr>
             </tbody>
           </table>

--- a/components/common/CardSelector.tsx
+++ b/components/common/CardSelector.tsx
@@ -21,10 +21,10 @@ interface CardSelectorProps {
 
 const RANKS = ['A', 'K', 'Q', 'J', 'T', '9', '8', '7', '6', '5', '4', '3', '2']
 const SUITS = [
-  { symbol: 's', name: '♠', color: 'text-gray-900 dark:text-white' },
+  { symbol: 's', name: '♠', color: 'text-foreground' },
   { symbol: 'h', name: '♥', color: 'text-red-600 dark:text-red-400' },
   { symbol: 'd', name: '♦', color: 'text-red-600 dark:text-red-400' },
-  { symbol: 'c', name: '♣', color: 'text-gray-900 dark:text-white' },
+  { symbol: 'c', name: '♣', color: 'text-foreground' },
 ]
 
 export function CardSelector({
@@ -55,7 +55,7 @@ export function CardSelector({
 
   const getSuitColor = (suitSymbol: string) => {
     const suit = SUITS.find(s => s.symbol === suitSymbol)
-    return suit?.color || 'text-gray-900 dark:text-white'
+    return suit?.color || 'text-foreground'
   }
 
   const getSuitName = (suitSymbol: string) => {
@@ -70,7 +70,7 @@ export function CardSelector({
           <div>
             <Label className="text-sm font-medium">{label}</Label>
             {description && (
-              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              <p className="text-xs text-muted-foreground mt-1">
                 {description}
               </p>
             )}
@@ -99,7 +99,7 @@ export function CardSelector({
             return (
               <div
                 key={card}
-                className="px-2 py-1 bg-white dark:bg-gray-800 border border-green-500 rounded text-sm font-mono font-bold flex items-center gap-1"
+                className="px-2 py-1 bg-card border border-green-500 rounded text-sm font-mono font-bold flex items-center gap-1"
               >
                 <span>{rank}</span>
                 <span className={getSuitColor(suit)}>{getSuitName(suit)}</span>
@@ -128,8 +128,8 @@ export function CardSelector({
                     "w-full px-1.5 py-1 text-xs font-mono font-bold rounded border transition-all",
                     isSelected
                       ? "bg-green-600 text-white border-green-600 shadow-md scale-105"
-                      : "bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 hover:border-green-400 hover:bg-green-50 dark:hover:bg-green-900/20",
-                    isDisabled && "opacity-30 cursor-not-allowed hover:border-gray-300 hover:bg-white dark:hover:bg-gray-800"
+                      : "bg-card border-border hover:border-green-400 hover:bg-green-50 dark:hover:bg-green-900/20",
+                    isDisabled && "opacity-30 cursor-not-allowed hover:border-border hover:bg-card"
                   )}
                 >
                   <span>{rank}</span>

--- a/components/common/NotificationBell.tsx
+++ b/components/common/NotificationBell.tsx
@@ -110,8 +110,8 @@ export function NotificationBell() {
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="relative hover:bg-gray-100 dark:hover:bg-gray-800">
-          <Bell className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+        <Button variant="ghost" size="icon" className="relative hover:bg-muted">
+          <Bell className="h-5 w-5 text-muted-foreground" />
           {unreadCount > 0 && (
             <Badge
               variant="destructive"
@@ -122,9 +122,9 @@ export function NotificationBell() {
           )}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-[380px] p-0 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700">
-        <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
-          <h3 className="font-semibold text-gray-900 dark:text-gray-100">Notifications</h3>
+      <DropdownMenuContent align="end" className="w-[380px] p-0 bg-background border-border">
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <h3 className="font-semibold text-foreground">Notifications</h3>
           <div className="flex gap-2">
             {unreadCount > 0 && (
               <Button
@@ -132,14 +132,14 @@ export function NotificationBell() {
                 size="sm"
                 onClick={handleMarkAllAsRead}
                 disabled={markAllAsReadMutation.isPending}
-                className="h-8 text-xs hover:bg-gray-100 dark:hover:bg-gray-700 dark:text-gray-300"
+                className="h-8 text-xs hover:bg-muted text-muted-foreground"
               >
                 <Check className="h-3 w-3 mr-1" />
                 Mark all read
               </Button>
             )}
             <Link href="/notifications">
-              <Button variant="ghost" size="sm" className="h-8 text-xs hover:bg-gray-100 dark:hover:bg-gray-700 dark:text-gray-300">
+              <Button variant="ghost" size="sm" className="h-8 text-xs hover:bg-muted text-muted-foreground">
                 View all
               </Button>
             </Link>
@@ -148,7 +148,7 @@ export function NotificationBell() {
 
         <ScrollArea className="h-[400px]">
           {notifications.length === 0 ? (
-            <div className="p-8 text-center text-gray-500 dark:text-gray-400">
+            <div className="p-8 text-center text-muted-foreground">
               <Bell className="h-12 w-12 mx-auto mb-2 opacity-50" />
               <p className="text-sm">No notifications yet</p>
             </div>
@@ -157,7 +157,7 @@ export function NotificationBell() {
               {notifications.map((notification) => (
                 <div
                   key={notification.id}
-                  className={`group relative px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer border-b border-gray-200 dark:border-gray-700 last:border-b-0 ${
+                  className={`group relative px-4 py-3 hover:bg-muted cursor-pointer border-b border-border last:border-b-0 ${
                     !notification.is_read ? "bg-gold-50 dark:bg-gold-900/10" : ""
                   }`}
                   onClick={() => handleNotificationClick(notification)}
@@ -176,27 +176,27 @@ export function NotificationBell() {
                       <Button
                         variant="ghost"
                         size="icon"
-                        className="h-6 w-6 hover:bg-gray-200 dark:hover:bg-gray-600"
+                        className="h-6 w-6 hover:bg-muted"
                         onClick={(e) => {
                           e.preventDefault()
                           e.stopPropagation()
                           handleMarkAsRead(notification.id)
                         }}
                       >
-                        <Check className="h-3 w-3 text-gray-600 dark:text-gray-400" />
+                        <Check className="h-3 w-3 text-muted-foreground" />
                       </Button>
                     )}
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-6 w-6 hover:bg-gray-200 dark:hover:bg-gray-600"
+                      className="h-6 w-6 hover:bg-muted"
                       onClick={(e) => {
                         e.preventDefault()
                         e.stopPropagation()
                         handleDelete(notification.id)
                       }}
                     >
-                      <Trash2 className="h-3 w-3 text-gray-600 dark:text-gray-400" />
+                      <Trash2 className="h-3 w-3 text-muted-foreground" />
                     </Button>
                   </div>
 
@@ -229,11 +229,11 @@ function NotificationItem({ notification }: { notification: Notification }) {
         </Avatar>
       )}
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium mb-1 text-gray-900 dark:text-gray-100">{notification.title}</p>
-        <p className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2 mb-1">
+        <p className="text-sm font-medium mb-1 text-foreground">{notification.title}</p>
+        <p className="text-xs text-muted-foreground line-clamp-2 mb-1">
           {notification.message}
         </p>
-        <p className="text-xs text-gray-500 dark:text-gray-400">
+        <p className="text-xs text-muted-foreground">
           {formatNotificationTime(notification.created_at)}
         </p>
       </div>

--- a/components/features/archive/ArchiveTournamentLogosBar.tsx
+++ b/components/features/archive/ArchiveTournamentLogosBar.tsx
@@ -107,7 +107,7 @@ export function ArchiveTournamentLogosBar({
                 "w-16 h-16 rounded-full flex items-center justify-center transition-all duration-200",
                 selectedCategory === 'All'
                   ? "text-white ring-2 ring-primary shadow-lg scale-110"
-                  : "text-gray-400"
+                  : "text-muted-foreground"
               )}
             >
               <LayoutGrid className="w-8 h-8" />
@@ -117,7 +117,7 @@ export function ArchiveTournamentLogosBar({
                 "text-xs font-medium transition-colors duration-200",
                 selectedCategory === 'All'
                   ? "text-white"
-                  : "text-gray-400"
+                  : "text-muted-foreground"
               )}
             >
               All
@@ -237,7 +237,7 @@ function TournamentLogoButton({
           isChildCategory ? "max-w-[48px]" : "max-w-[64px]",
           isSelected
             ? "text-white"
-            : "text-gray-400 group-hover:text-gray-300"
+            : "text-muted-foreground group-hover:text-foreground"
         )}
       >
         {category.display_name}

--- a/components/features/community/CommunityFilters.tsx
+++ b/components/features/community/CommunityFilters.tsx
@@ -22,7 +22,7 @@ const categoryColors: Record<PostCategory, string> = {
   "analysis": "bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-800",
   "strategy": "bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 hover:bg-green-200 dark:hover:bg-green-800",
   "hand-review": "bg-purple-100 dark:bg-purple-900 text-purple-700 dark:text-purple-300 hover:bg-purple-200 dark:hover:bg-purple-800",
-  "general": "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
+  "general": "bg-muted text-foreground hover:bg-accent"
 }
 
 const categoryLabels: Record<PostCategory, string> = {
@@ -44,15 +44,15 @@ export function CommunityFilters({
   const hasFilters = selectedCategory || dateFrom || dateTo
 
   return (
-    <Card className="p-4 rounded-lg border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+    <Card className="p-4 rounded-lg border bg-card">
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">고급 필터</h3>
+        <h3 className="text-sm font-semibold text-foreground">고급 필터</h3>
         {hasFilters && (
           <Button
             variant="ghost"
             size="sm"
             onClick={onReset}
-            className="h-7 text-xs text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
+            className="h-7 text-xs text-muted-foreground hover:text-foreground"
           >
             <X className="h-3 w-3 mr-1" />
             초기화
@@ -63,7 +63,7 @@ export function CommunityFilters({
       <div className="space-y-4">
         {/* Category Filter */}
         <div className="space-y-2">
-          <Label className="text-xs text-gray-700 dark:text-gray-300">카테고리</Label>
+          <Label className="text-xs text-foreground">카테고리</Label>
           <div className="grid grid-cols-2 gap-2">
             {Object.entries(categoryColors).map(([category, colorClass]) => (
               <button
@@ -87,7 +87,7 @@ export function CommunityFilters({
           </div>
           {selectedCategory && (
             <div className="flex items-center gap-1 mt-2">
-              <span className="text-xs text-gray-600 dark:text-gray-400">선택됨:</span>
+              <span className="text-xs text-muted-foreground">선택됨:</span>
               <Badge className={categoryColors[selectedCategory]}>
                 {categoryLabels[selectedCategory]}
               </Badge>
@@ -97,7 +97,7 @@ export function CommunityFilters({
 
         {/* Date Range Filter */}
         <div className="space-y-2">
-          <Label className="text-xs text-gray-700 dark:text-gray-300">날짜 범위</Label>
+          <Label className="text-xs text-foreground">날짜 범위</Label>
           <div className="grid grid-cols-2 gap-2">
             <div>
               <Input
@@ -105,7 +105,7 @@ export function CommunityFilters({
                 value={dateFrom || ""}
                 onChange={(e) => onDateFromChange(e.target.value)}
                 placeholder="시작일"
-                className="text-xs rounded-md bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100"
+                className="text-xs rounded-md bg-muted border text-foreground"
               />
             </div>
             <div>
@@ -114,7 +114,7 @@ export function CommunityFilters({
                 value={dateTo || ""}
                 onChange={(e) => onDateToChange(e.target.value)}
                 placeholder="종료일"
-                className="text-xs rounded-md bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100"
+                className="text-xs rounded-md bg-muted border text-foreground"
               />
             </div>
           </div>

--- a/components/features/community/CommunitySearchBar.tsx
+++ b/components/features/community/CommunitySearchBar.tsx
@@ -59,18 +59,18 @@ export function CommunitySearchBar({
   return (
     <div className="flex gap-2">
       <div className="relative flex-1">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 dark:text-gray-400" />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
         <Input
           type="text"
           placeholder="포스트 검색... (제목, 내용)"
           value={searchValue}
           onChange={handleChange}
-          className="pl-10 pr-10 rounded-md bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 placeholder:text-gray-500 dark:placeholder:text-gray-400"
+          className="pl-10 pr-10 rounded-md bg-card border-border text-foreground placeholder:text-muted-foreground"
         />
         {searchValue && (
           <button
             onClick={handleClear}
-            className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+            className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground hover:text-foreground transition-colors"
           >
             <X className="h-4 w-4" />
           </button>

--- a/components/features/community/PostComments.tsx
+++ b/components/features/community/PostComments.tsx
@@ -211,7 +211,7 @@ export function PostComments({ postId, handId, onCommentsCountChange }: PostComm
     return (
       <div
         key={comment.id}
-        className={`${isReply ? "ml-6 md:ml-10 pl-3 md:pl-4 border-l-2 border-gray-200 dark:border-gray-700" : ""}`}
+        className={`${isReply ? "ml-6 md:ml-10 pl-3 md:pl-4 border-l-2 border-border" : ""}`}
       >
         <div className="flex gap-3">
           <Avatar className="h-8 w-8 rounded-full">
@@ -223,8 +223,8 @@ export function PostComments({ postId, handId, onCommentsCountChange }: PostComm
 
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-2">
-              <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">{comment.author.name}</span>
-              <span className="text-xs text-gray-600 dark:text-gray-400">
+              <span className="text-sm font-semibold text-foreground">{comment.author.name}</span>
+              <span className="text-xs text-muted-foreground">
                 {new Date(comment.createdAt).toLocaleDateString("en-US", {
                   year: "numeric",
                   month: "short",
@@ -235,14 +235,14 @@ export function PostComments({ postId, handId, onCommentsCountChange }: PostComm
               </span>
             </div>
 
-            <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap mb-3 leading-normal">
+            <p className="text-sm text-foreground whitespace-pre-wrap mb-3 leading-normal">
               {comment.content}
             </p>
 
             <div className="flex items-center gap-3">
               <button
                 onClick={() => handleLikeComment(comment.id)}
-                className="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors focus:ring-2 focus:ring-blue-400"
+                className="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium text-foreground hover:bg-accent transition-colors focus:ring-2 focus:ring-blue-400"
               >
                 <ThumbsUp className="h-3 w-3" />
                 <span className="font-mono">{comment.likesCount}</span>
@@ -260,7 +260,7 @@ export function PostComments({ postId, handId, onCommentsCountChange }: PostComm
                       }
                     }
                   }}
-                  className="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors focus:ring-2 focus:ring-blue-400"
+                  className="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium text-foreground hover:bg-accent transition-colors focus:ring-2 focus:ring-blue-400"
                 >
                   <MessageCircle className="h-3 w-3" />
                   <span>Reply</span>
@@ -282,12 +282,12 @@ export function PostComments({ postId, handId, onCommentsCountChange }: PostComm
                     }))
                   }
                   rows={2}
-                  className="w-full resize-none rounded-md bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100"
+                  className="w-full resize-none rounded-md bg-card border text-foreground"
                 />
                 <div className="flex gap-2 justify-end">
                   <button
                     onClick={() => setReplyingTo(null)}
-                    className="px-3 py-1 text-xs font-medium bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                    className="px-3 py-1 text-xs font-medium bg-card border text-foreground rounded-md hover:bg-accent transition-colors"
                   >
                     Cancel
                   </button>
@@ -312,7 +312,7 @@ export function PostComments({ postId, handId, onCommentsCountChange }: PostComm
 
             {/* Loading replies */}
             {comment.isLoadingReplies && (
-              <div className="mt-3 text-xs text-gray-600 dark:text-gray-400">
+              <div className="mt-3 text-xs text-muted-foreground">
                 Loading replies...
               </div>
             )}
@@ -323,8 +323,8 @@ export function PostComments({ postId, handId, onCommentsCountChange }: PostComm
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
-      <h4 className="text-lg font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2 mb-6">
+    <div className="bg-card rounded-lg border p-6">
+      <h4 className="text-lg font-semibold text-foreground flex items-center gap-2 mb-6">
         <MessageCircle className="h-5 w-5" />
         <span className="font-mono">
           Comments ({comments.reduce((acc, c) => acc + 1 + (c.replies?.length || 0), 0)})
@@ -343,7 +343,7 @@ export function PostComments({ postId, handId, onCommentsCountChange }: PostComm
           onChange={(e) => setNewComment(e.target.value)}
           rows={3}
           disabled={!user}
-          className="w-full resize-none mb-2 rounded-md bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 placeholder:text-gray-500 dark:placeholder:text-gray-400"
+          className="w-full resize-none mb-2 rounded-md bg-muted border text-foreground placeholder:text-muted-foreground"
         />
         <div className="flex justify-end">
           <button
@@ -360,11 +360,11 @@ export function PostComments({ postId, handId, onCommentsCountChange }: PostComm
       {/* Comments list */}
       <div className="space-y-4">
         {loading ? (
-          <div className="text-center text-sm text-gray-600 dark:text-gray-400 py-8">
+          <div className="text-center text-sm text-muted-foreground py-8">
             Loading comments...
           </div>
         ) : comments.length === 0 ? (
-          <div className="text-center text-sm text-gray-600 dark:text-gray-400 py-8">
+          <div className="text-center text-sm text-muted-foreground py-8">
             첫 댓글을 작성해보세요!
           </div>
         ) : (

--- a/components/features/hand/HandHistoryTimeline.tsx
+++ b/components/features/hand/HandHistoryTimeline.tsx
@@ -212,7 +212,7 @@ export function HandHistoryTimeline({ handId }: HandHistoryTimelineProps) {
                       </div>
                     ) : (
                       <div className="text-muted-foreground text-sm text-center">-</div>
-                    ))}
+                    )}
                   </div>
                 )
               })}

--- a/components/features/hand/HandHistoryTimeline.tsx
+++ b/components/features/hand/HandHistoryTimeline.tsx
@@ -33,7 +33,7 @@ function ActionBadge({ action }: { action: HandAction }) {
   // Check
   if (action_type === 'check') {
     return (
-      <div className="px-3 py-1.5 rounded bg-white border border-gray-300 text-black text-sm font-medium">
+      <div className="px-3 py-1.5 rounded bg-white border border-border text-black text-sm font-medium">
         Check
       </div>
     )
@@ -50,7 +50,7 @@ function ActionBadge({ action }: { action: HandAction }) {
 
   // Call, Bet, Raise (흰색 배경 with amount)
   return (
-    <div className="px-3 py-1.5 rounded bg-white border border-gray-300 text-black text-sm font-medium">
+    <div className="px-3 py-1.5 rounded bg-white border border-border text-black text-sm font-medium">
       {action_type.charAt(0).toUpperCase() + action_type.slice(1)}{' '}
       {amount && amount > 0 && `(${amount.toLocaleString()})`}
     </div>
@@ -138,16 +138,16 @@ export function HandHistoryTimeline({ handId }: HandHistoryTimelineProps) {
     <div className="overflow-x-auto">
       <div className="min-w-[800px]">
         {/* CSS Grid: 5 columns (player + 4 streets) */}
-        <div className="grid grid-cols-5 gap-0 border border-gray-700 rounded-lg overflow-hidden">
+        <div className="grid grid-cols-5 gap-0 border border-border rounded-lg overflow-hidden">
           {/* Header Row */}
-          <div className="bg-gray-900" /> {/* Empty top-left cell */}
+          <div className="bg-background" /> {/* Empty top-left cell */}
 
           {streets.map(({ key, label }) => (
             <div
               key={key}
-              className="bg-gray-800 p-4 text-center border-l border-gray-700 first:border-l-0"
+              className="bg-muted p-4 text-center border-l border-border first:border-l-0"
             >
-              <div className="text-white font-semibold text-lg mb-1">{label}</div>
+              <div className="text-foreground font-semibold text-lg mb-1">{label}</div>
               <div className="text-yellow-500 font-medium">
                 {potSizes[key] > 0 ? potSizes[key].toLocaleString() : '-'}
               </div>
@@ -160,27 +160,27 @@ export function HandHistoryTimeline({ handId }: HandHistoryTimelineProps) {
               key={player.id}
               className={cn(
                 'contents',
-                idx !== players.length - 1 && 'border-b border-gray-700'
+                idx !== players.length - 1 && 'border-b border-border'
               )}
             >
               {/* Column 1: Player Info (NO HEADER) */}
-              <div className="bg-gray-700 p-4 flex items-center gap-3 border-t border-gray-700 first:border-t-0">
+              <div className="bg-muted p-4 flex items-center gap-3 border-t border-border first:border-t-0">
                 {player.player?.photo_url && (
                   <img
                     src={player.player.photo_url}
                     alt={player.player.name}
-                    className="w-12 h-12 rounded-full object-cover border-2 border-gray-600"
+                    className="w-12 h-12 rounded-full object-cover border-2 border-border"
                   />
                 )}
                 <div className="flex-1 min-w-0">
                   {player.player ? (
                     <PlayerHoverCard player={player.player}>
-                      <div className="text-white font-medium truncate">
+                      <div className="text-foreground font-medium truncate">
                         {player.player.name}
                       </div>
                     </PlayerHoverCard>
                   ) : (
-                    <div className="text-white font-medium truncate">
+                    <div className="text-foreground font-medium truncate">
                       Unknown Player
                     </div>
                   )}
@@ -190,7 +190,7 @@ export function HandHistoryTimeline({ handId }: HandHistoryTimelineProps) {
                     </div>
                   )}
                   {player.cards && (
-                    <div className="text-xs text-gray-400 mt-1">{player.cards}</div>
+                    <div className="text-xs text-muted-foreground mt-1">{player.cards}</div>
                   )}
                 </div>
               </div>
@@ -202,7 +202,7 @@ export function HandHistoryTimeline({ handId }: HandHistoryTimelineProps) {
                 return (
                   <div
                     key={key}
-                    className="p-4 bg-gray-900 border-l border-t border-gray-700 first:border-l-0 first:border-t-0"
+                    className="p-4 bg-background border-l border-t border-border first:border-l-0 first:border-t-0"
                   >
                     {playerActions.length > 0 ? (
                       <div className="flex flex-col gap-2">
@@ -211,8 +211,8 @@ export function HandHistoryTimeline({ handId }: HandHistoryTimelineProps) {
                         ))}
                       </div>
                     ) : (
-                      <div className="text-gray-600 text-sm text-center">-</div>
-                    )}
+                      <div className="text-muted-foreground text-sm text-center">-</div>
+                    ))}
                   </div>
                 )
               })}

--- a/components/features/hand/HandTagDialog.tsx
+++ b/components/features/hand/HandTagDialog.tsx
@@ -72,7 +72,7 @@ export function HandTagDialog({
       red: "border-red-500 text-red-700 bg-red-50 hover:bg-red-100",
       green: "border-green-500 text-green-700 bg-green-50 hover:bg-green-100",
     }
-    return colorMap[colorName] || "border-gray-500 text-gray-700 bg-gray-50 hover:bg-gray-100"
+    return colorMap[colorName] || "border-border text-foreground bg-muted hover:bg-accent"
   }
 
   const getSelectedClass = (colorName: string) => {
@@ -81,7 +81,7 @@ export function HandTagDialog({
       red: "bg-red-500 text-white border-red-600",
       green: "bg-green-500 text-white border-green-600",
     }
-    return colorMap[colorName] || "bg-gray-500 text-white border-gray-600"
+    return colorMap[colorName] || "bg-accent text-accent-foreground border-border"
   }
 
   return (

--- a/components/features/player/PlayerCard.tsx
+++ b/components/features/player/PlayerCard.tsx
@@ -40,10 +40,10 @@ export function PlayerCard({ player, className, index = 0 }: PlayerCardProps) {
       className={cn('flex-shrink-0', className)}
     >
       <Link href={`/players/${player.id}`}>
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 hover:shadow-md transition-all duration-200 p-4 cursor-pointer min-w-[140px]">
+        <div className="bg-card rounded-lg shadow-sm border border-border hover:shadow-md transition-all duration-200 p-4 cursor-pointer min-w-[140px]">
           <div className="flex flex-col items-center space-y-3">
             {/* Avatar */}
-            <div className="w-16 h-16 rounded-full border-2 border-gray-100 dark:border-gray-700 overflow-hidden bg-gray-100 dark:bg-gray-700">
+            <div className="w-16 h-16 rounded-full border-2 border-muted overflow-hidden bg-muted">
               {player.photo_url ? (
                 <img
                   src={player.photo_url}
@@ -65,13 +65,13 @@ export function PlayerCard({ player, className, index = 0 }: PlayerCardProps) {
 
             {/* Name */}
             <div className="text-center space-y-1 w-full">
-              <p className="text-sm font-semibold text-gray-900 dark:text-gray-100 leading-tight line-clamp-2">
+              <p className="text-sm font-semibold text-foreground leading-tight line-clamp-2">
                 {player.name}
               </p>
 
               {/* Country */}
               {player.country && (
-                <p className="text-xs text-gray-600 dark:text-gray-400">{player.country}</p>
+                <p className="text-xs text-muted-foreground">{player.country}</p>
               )}
             </div>
 

--- a/components/features/player/PlayerCharts.tsx
+++ b/components/features/player/PlayerCharts.tsx
@@ -11,7 +11,7 @@ type PrizeHistoryChartProps = {
 export function PrizeHistoryChart({ data }: PrizeHistoryChartProps) {
   if (data.length === 0) {
     return (
-      <div className="h-[300px] flex items-center justify-center text-gray-600 dark:text-gray-400">
+      <div className="h-[300px] flex items-center justify-center text-muted-foreground">
         <p>No prize history available</p>
       </div>
     )
@@ -26,7 +26,7 @@ export function PrizeHistoryChart({ data }: PrizeHistoryChartProps) {
             <stop offset="95%" stopColor="#8884d8" stopOpacity={0}/>
           </linearGradient>
         </defs>
-        <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-700" />
+        <CartesianGrid strokeDasharray="3 3" className="stroke-border" opacity={0.2} />
         <XAxis
           dataKey="date"
           tickFormatter={(value) => {
@@ -34,7 +34,7 @@ export function PrizeHistoryChart({ data }: PrizeHistoryChartProps) {
             return date.toLocaleDateString('en-US', { month: 'short', year: '2-digit' })
           }}
           tick={{ fontSize: 12, fill: 'currentColor' }}
-          className="text-gray-600 dark:text-gray-400"
+          className="text-muted-foreground"
         />
         <YAxis
           tickFormatter={(value) => {
@@ -43,7 +43,7 @@ export function PrizeHistoryChart({ data }: PrizeHistoryChartProps) {
             return `$${value}`
           }}
           tick={{ fontSize: 12, fill: 'currentColor' }}
-          className="text-gray-600 dark:text-gray-400"
+          className="text-muted-foreground"
         />
         <Tooltip
           formatter={(value: any) => [`$${value.toLocaleString()}`, 'Prize']}
@@ -52,9 +52,10 @@ export function PrizeHistoryChart({ data }: PrizeHistoryChartProps) {
             return item ? `${item.eventName} (Rank ${item.rank})` : label
           }}
           contentStyle={{
-            backgroundColor: 'rgba(255, 255, 255, 0.95)',
-            border: '1px solid rgba(209, 213, 219, 1)',
+            backgroundColor: 'hsl(var(--card))',
+            border: '1px solid hsl(var(--border))',
             borderRadius: '8px',
+            color: 'hsl(var(--foreground))'
           }}
         />
         <Area
@@ -93,9 +94,10 @@ export function TournamentCategoryChart({ data }: TournamentCategoryChartProps) 
         </Pie>
         <Tooltip
           contentStyle={{
-            backgroundColor: 'rgba(255, 255, 255, 0.95)',
-            border: '1px solid rgba(209, 213, 219, 1)',
+            backgroundColor: 'hsl(var(--card))',
+            border: '1px solid hsl(var(--border))',
             borderRadius: '8px',
+            color: 'hsl(var(--foreground))'
           }}
         />
       </RechartsPie>

--- a/components/features/player/PlayerStats.tsx
+++ b/components/features/player/PlayerStats.tsx
@@ -82,17 +82,17 @@ export function AdvancedStatsCard({ playerId }: { playerId: string }) {
   ]
 
   const getTrendIcon = (value: number, benchmark?: { low: number; high: number }) => {
-    if (!benchmark) return <Minus className="h-4 w-4 text-gray-400" />
+    if (!benchmark) return <Minus className="h-4 w-4 text-muted-foreground" />
     if (value > benchmark.high) return <TrendingUp className="h-4 w-4 text-green-600 dark:text-green-400" />
     if (value < benchmark.low) return <TrendingDown className="h-4 w-4 text-red-600 dark:text-red-400" />
-    return <Minus className="h-4 w-4 text-gray-400" />
+    return <Minus className="h-4 w-4 text-muted-foreground" />
   }
 
   const getStatColor = (value: number, benchmark?: { low: number; high: number }) => {
-    if (!benchmark) return 'text-gray-900 dark:text-gray-100'
+    if (!benchmark) return 'text-foreground'
     if (value > benchmark.high) return 'text-green-600 dark:text-green-400'
     if (value < benchmark.low) return 'text-red-600 dark:text-red-400'
-    return 'text-gray-900 dark:text-gray-100'
+    return 'text-foreground'
   }
 
   return (

--- a/components/features/player/PlayerStats.tsx
+++ b/components/features/player/PlayerStats.tsx
@@ -14,12 +14,12 @@ export function AdvancedStatsCard({ playerId }: { playerId: string }) {
 
   if (isLoading) {
     return (
-      <Card className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">고급 통계</h3>
+      <Card className="bg-card rounded-lg shadow-sm border border-border p-6">
+        <h3 className="text-lg font-semibold text-foreground mb-4">고급 통계</h3>
         <div className="animate-pulse space-y-4">
-          <div className="h-16 bg-gray-200 dark:bg-gray-700 rounded" />
-          <div className="h-16 bg-gray-200 dark:bg-gray-700 rounded" />
-          <div className="h-16 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="h-16 bg-muted rounded" />
+          <div className="h-16 bg-muted rounded" />
+          <div className="h-16 bg-muted rounded" />
         </div>
       </Card>
     )
@@ -27,9 +27,9 @@ export function AdvancedStatsCard({ playerId }: { playerId: string }) {
 
   if (error || isStatsEmpty(stats)) {
     return (
-      <Card className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">고급 통계</h3>
-        <p className="text-sm text-gray-600 dark:text-gray-400">
+      <Card className="bg-card rounded-lg shadow-sm border border-border p-6">
+        <h3 className="text-lg font-semibold text-foreground mb-4">고급 통계</h3>
+        <p className="text-sm text-muted-foreground">
           충분한 핸드 데이터가 없습니다. 최소 20핸드 이상 필요합니다.
         </p>
       </Card>
@@ -96,11 +96,11 @@ export function AdvancedStatsCard({ playerId }: { playerId: string }) {
   }
 
   return (
-    <Card className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+    <Card className="bg-card rounded-lg shadow-sm border border-border p-6">
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">고급 통계</h3>
+        <h3 className="text-lg font-semibold text-foreground">고급 통계</h3>
         {playStyle && (
-          <div className={`inline-flex items-center px-3 py-1 bg-gray-100 dark:bg-gray-700 rounded-lg ${playStyle.color}`}>
+          <div className={`inline-flex items-center px-3 py-1 bg-muted rounded-lg ${playStyle.color}`}>
             <span className="text-sm font-medium">{playStyle.style}</span>
           </div>
         )}
@@ -110,13 +110,13 @@ export function AdvancedStatsCard({ playerId }: { playerId: string }) {
         {statItems.map((item) => (
           <div key={item.label} className="space-y-2">
             <div className="flex items-center justify-between">
-              <span className="text-xs font-medium text-gray-500 dark:text-gray-400">{item.label}</span>
+              <span className="text-xs font-medium text-muted-foreground">{item.label}</span>
               {getTrendIcon(item.value, item.benchmark)}
             </div>
             <div className={`text-2xl font-bold font-mono ${getStatColor(item.value, item.benchmark)}`}>
               {item.isNotPercentage ? formatPotSize(item.value) : formatStatPercentage(item.value)}
             </div>
-            <p className="text-xs text-gray-600 dark:text-gray-400" title={item.tooltip}>
+            <p className="text-xs text-muted-foreground" title={item.tooltip}>
               {item.description}
             </p>
           </div>
@@ -124,15 +124,15 @@ export function AdvancedStatsCard({ playerId }: { playerId: string }) {
       </div>
 
       {playStyle && (
-        <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
-          <p className="text-sm text-gray-600 dark:text-gray-400">
+        <div className="mt-4 pt-4 border-t border-border">
+          <p className="text-sm text-muted-foreground">
             {playStyle.description}
           </p>
         </div>
       )}
 
-      <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
-        <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+      <div className="mt-4 pt-4 border-t border-border">
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
           <span>Total Hands: <span className="font-mono font-semibold">{stats!.totalHands}</span></span>
           <span>Hands Won: <span className="font-mono font-semibold">{stats!.handsWon}</span></span>
         </div>
@@ -149,18 +149,18 @@ export function PositionalStatsCard({ playerId }: { playerId: string }) {
 
   if (isLoading) {
     return (
-      <Card className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">포지션별 통계</h3>
-        <div className="animate-pulse h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+      <Card className="bg-card rounded-lg shadow-sm border border-border p-6">
+        <h3 className="text-lg font-semibold text-foreground mb-4">포지션별 통계</h3>
+        <div className="animate-pulse h-64 bg-muted rounded" />
       </Card>
     )
   }
 
   if (error || !positionStats || positionStats.length === 0) {
     return (
-      <Card className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">포지션별 통계</h3>
-        <p className="text-sm text-gray-600 dark:text-gray-400">
+      <Card className="bg-card rounded-lg shadow-sm border border-border p-6">
+        <h3 className="text-lg font-semibold text-foreground mb-4">포지션별 통계</h3>
+        <p className="text-sm text-muted-foreground">
           포지션별 데이터가 없습니다.
         </p>
       </Card>
@@ -176,27 +176,27 @@ export function PositionalStatsCard({ playerId }: { playerId: string }) {
   }))
 
   return (
-    <Card className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">포지션별 통계</h3>
+    <Card className="bg-card rounded-lg shadow-sm border border-border p-6">
+      <h3 className="text-lg font-semibold text-foreground mb-4">포지션별 통계</h3>
 
       <ResponsiveContainer width="100%" height={300}>
         <BarChart data={chartData}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#374151" opacity={0.2} />
+          <CartesianGrid strokeDasharray="3 3" className="stroke-border" opacity={0.2} />
           <XAxis
             dataKey="position"
-            stroke="#9CA3AF"
+            className="text-muted-foreground"
             style={{ fontSize: '12px' }}
           />
           <YAxis
-            stroke="#9CA3AF"
+            className="text-muted-foreground"
             style={{ fontSize: '12px' }}
           />
           <Tooltip
             contentStyle={{
-              backgroundColor: '#1F2937',
-              border: '1px solid #374151',
+              backgroundColor: 'hsl(var(--card))',
+              border: '1px solid hsl(var(--border))',
               borderRadius: '8px',
-              color: '#F9FAFB'
+              color: 'hsl(var(--foreground))'
             }}
             formatter={(value: number, name: string) => [
               name === 'hands' ? value : `${value}%`,
@@ -213,19 +213,19 @@ export function PositionalStatsCard({ playerId }: { playerId: string }) {
         <div>
           <div className="flex items-center justify-center gap-2 mb-1">
             <div className="w-3 h-3 bg-green-600 dark:bg-green-500 rounded" />
-            <span className="text-gray-600 dark:text-gray-400">VPIP</span>
+            <span className="text-muted-foreground">VPIP</span>
           </div>
         </div>
         <div>
           <div className="flex items-center justify-center gap-2 mb-1">
             <div className="w-3 h-3 bg-blue-600 dark:bg-blue-500 rounded" />
-            <span className="text-gray-600 dark:text-gray-400">PFR</span>
+            <span className="text-muted-foreground">PFR</span>
           </div>
         </div>
         <div>
           <div className="flex items-center justify-center gap-2 mb-1">
             <div className="w-3 h-3 bg-yellow-600 dark:bg-yellow-500 rounded" />
-            <span className="text-gray-600 dark:text-gray-400">Win Rate</span>
+            <span className="text-muted-foreground">Win Rate</span>
           </div>
         </div>
       </div>
@@ -242,18 +242,18 @@ export function PerformanceChartCard({ playerId }: { playerId: string }) {
 
   if (isLoading) {
     return (
-      <Card className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">성과 분석</h3>
-        <div className="animate-pulse h-64 bg-gray-200 dark:bg-gray-700 rounded" />
+      <Card className="bg-card rounded-lg shadow-sm border border-border p-6">
+        <h3 className="text-lg font-semibold text-foreground mb-4">성과 분석</h3>
+        <div className="animate-pulse h-64 bg-muted rounded" />
       </Card>
     )
   }
 
   if (isStatsEmpty(stats) || !positionStats || positionStats.length === 0) {
     return (
-      <Card className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">성과 분석</h3>
-        <p className="text-sm text-gray-600 dark:text-gray-400">
+      <Card className="bg-card rounded-lg shadow-sm border border-border p-6">
+        <h3 className="text-lg font-semibold text-foreground mb-4">성과 분석</h3>
+        <p className="text-sm text-muted-foreground">
           성과 데이터가 없습니다.
         </p>
       </Card>
@@ -274,31 +274,31 @@ export function PerformanceChartCard({ playerId }: { playerId: string }) {
   }
 
   return (
-    <Card className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">성과 분석</h3>
+    <Card className="bg-card rounded-lg shadow-sm border border-border p-6">
+      <h3 className="text-lg font-semibold text-foreground mb-4">성과 분석</h3>
 
       <ResponsiveContainer width="100%" height={300}>
         <BarChart data={performanceData} layout="vertical">
-          <CartesianGrid strokeDasharray="3 3" stroke="#374151" opacity={0.2} />
+          <CartesianGrid strokeDasharray="3 3" className="stroke-border" opacity={0.2} />
           <XAxis
             type="number"
-            stroke="#9CA3AF"
+            className="text-muted-foreground"
             style={{ fontSize: '12px' }}
             domain={[0, 100]}
           />
           <YAxis
             type="category"
             dataKey="position"
-            stroke="#9CA3AF"
+            className="text-muted-foreground"
             style={{ fontSize: '12px' }}
             width={60}
           />
           <Tooltip
             contentStyle={{
-              backgroundColor: '#1F2937',
-              border: '1px solid #374151',
+              backgroundColor: 'hsl(var(--card))',
+              border: '1px solid hsl(var(--border))',
               borderRadius: '8px',
-              color: '#F9FAFB'
+              color: 'hsl(var(--foreground))'
             }}
             formatter={(value: number, name: string) => [
               name === 'hands' ? value : `${value}%`,
@@ -313,23 +313,23 @@ export function PerformanceChartCard({ playerId }: { playerId: string }) {
         </BarChart>
       </ResponsiveContainer>
 
-      <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+      <div className="mt-4 pt-4 border-t border-border">
         <div className="grid grid-cols-4 gap-2 text-xs">
           <div className="flex items-center gap-2">
             <div className="w-3 h-3 bg-green-600 rounded" />
-            <span className="text-gray-600 dark:text-gray-400">≥50%</span>
+            <span className="text-muted-foreground">≥50%</span>
           </div>
           <div className="flex items-center gap-2">
             <div className="w-3 h-3 bg-blue-600 rounded" />
-            <span className="text-gray-600 dark:text-gray-400">40-49%</span>
+            <span className="text-muted-foreground">40-49%</span>
           </div>
           <div className="flex items-center gap-2">
             <div className="w-3 h-3 bg-yellow-600 rounded" />
-            <span className="text-gray-600 dark:text-gray-400">30-39%</span>
+            <span className="text-muted-foreground">30-39%</span>
           </div>
           <div className="flex items-center gap-2">
             <div className="w-3 h-3 bg-red-600 rounded" />
-            <span className="text-gray-600 dark:text-gray-400">&lt;30%</span>
+            <span className="text-muted-foreground">&lt;30%</span>
           </div>
         </div>
       </div>

--- a/components/features/player/stats/AdvancedStatsCard.tsx
+++ b/components/features/player/stats/AdvancedStatsCard.tsx
@@ -147,9 +147,9 @@ export function AdvancedStatsCard({ playerId }: AdvancedStatsCardProps) {
         </div>
 
         {playStyle && (
-          <div className="mt-6 rounded-lg bg-gray-100 dark:bg-gray-700 p-4">
-            <p className="text-sm font-medium mb-1 text-gray-900 dark:text-gray-100">플레이 스타일</p>
-            <p className="text-xs text-gray-600 dark:text-gray-400">{playStyle.description}</p>
+          <div className="mt-6 rounded-lg bg-muted p-4">
+            <p className="text-sm font-medium mb-1 text-foreground">플레이 스타일</p>
+            <p className="text-xs text-muted-foreground">{playStyle.description}</p>
           </div>
         )}
       </CardContent>

--- a/components/features/player/stats/AdvancedStatsCard.tsx
+++ b/components/features/player/stats/AdvancedStatsCard.tsx
@@ -65,7 +65,7 @@ export function AdvancedStatsCard({ playerId }: AdvancedStatsCardProps) {
   const isPremium = stats.totalHands > 50
 
   return (
-    <Card className={isPremium ? 'border-gold-500/50 bg-gradient-to-br from-gray-800 to-gray-900' : undefined}>
+    <Card className={isPremium ? 'border-gold-500/50 bg-gradient-to-br from-muted to-background' : undefined}>
       <CardHeader>
         <div className="flex items-center justify-between">
           <div>

--- a/components/features/player/stats/PerformanceChartCard.tsx
+++ b/components/features/player/stats/PerformanceChartCard.tsx
@@ -92,7 +92,7 @@ export function PerformanceChartCard({ playerId }: PerformanceChartCardProps) {
   const isPremium = posStats.length >= 5 // 5개 이상 포지션 데이터
 
   return (
-    <Card className={isPremium ? 'border-gold-500/50 bg-gradient-to-br from-gray-800 to-gray-900' : undefined}>
+    <Card className={isPremium ? 'border-gold-500/50 bg-gradient-to-br from-muted to-background' : undefined}>
       <CardHeader>
         <CardTitle className={isPremium ? 'bg-gradient-to-r from-gold-400 to-gold-600 bg-clip-text text-transparent' : undefined}>
           성과 차트

--- a/components/features/player/stats/PerformanceChartCard.tsx
+++ b/components/features/player/stats/PerformanceChartCard.tsx
@@ -112,10 +112,10 @@ export function PerformanceChartCard({ playerId }: PerformanceChartCardProps) {
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
                 <XAxis
                   dataKey="position"
-                  className="text-xs text-gray-600 dark:text-gray-400"
+                  className="text-xs text-muted-foreground"
                   tick={{ fill: 'currentColor' }}
                 />
-                <YAxis className="text-xs text-gray-600 dark:text-gray-400" tick={{ fill: 'currentColor' }} />
+                <YAxis className="text-xs text-muted-foreground" tick={{ fill: 'currentColor' }} />
                 <Tooltip
                   contentStyle={{
                     backgroundColor: 'var(--tw-bg-opacity, 1)',
@@ -131,9 +131,9 @@ export function PerformanceChartCard({ playerId }: PerformanceChartCardProps) {
               </RechartsBarChart>
             </ResponsiveContainer>
 
-            <div className="mt-4 grid grid-cols-2 gap-4 text-xs text-gray-600 dark:text-gray-400">
+            <div className="mt-4 grid grid-cols-2 gap-4 text-xs text-muted-foreground">
               <div>
-                <p className="font-medium mb-1 text-gray-900 dark:text-gray-100">차트 설명</p>
+                <p className="font-medium mb-1 text-foreground">차트 설명</p>
                 <ul className="space-y-1">
                   <li>• 파란색: VPIP (자발적 팟 참여율)</li>
                   <li>• 초록색: PFR (프리플롭 레이즈율)</li>
@@ -141,7 +141,7 @@ export function PerformanceChartCard({ playerId }: PerformanceChartCardProps) {
                 </ul>
               </div>
               <div>
-                <p className="font-medium mb-1 text-gray-900 dark:text-gray-100">분석 포인트</p>
+                <p className="font-medium mb-1 text-foreground">분석 포인트</p>
                 <ul className="space-y-1">
                   <li>• BTN, CO: 높은 VPIP/PFR 권장</li>
                   <li>• UTG: 낮은 VPIP/PFR 권장</li>
@@ -154,16 +154,16 @@ export function PerformanceChartCard({ playerId }: PerformanceChartCardProps) {
           <TabsContent value="radar" className="mt-6">
             <ResponsiveContainer width="100%" height={300}>
               <RadarChart data={radarChartData}>
-                <PolarGrid className="stroke-gray-200 dark:stroke-gray-700" />
+                <PolarGrid className="stroke-border" />
                 <PolarAngleAxis
                   dataKey="stat"
-                  className="text-xs text-gray-600 dark:text-gray-400"
+                  className="text-xs text-muted-foreground"
                   tick={{ fill: 'currentColor' }}
                 />
                 <PolarRadiusAxis
                   angle={90}
                   domain={[0, 100]}
-                  className="text-xs text-gray-600 dark:text-gray-400"
+                  className="text-xs text-muted-foreground"
                   tick={{ fill: 'currentColor' }}
                 />
                 <Radar
@@ -185,9 +185,9 @@ export function PerformanceChartCard({ playerId }: PerformanceChartCardProps) {
               </RadarChart>
             </ResponsiveContainer>
 
-            <div className="mt-4 grid grid-cols-2 gap-4 text-xs text-gray-600 dark:text-gray-400">
+            <div className="mt-4 grid grid-cols-2 gap-4 text-xs text-muted-foreground">
               <div>
-                <p className="font-medium mb-1 text-gray-900 dark:text-gray-100">현재 통계</p>
+                <p className="font-medium mb-1 text-foreground">현재 통계</p>
                 <ul className="space-y-1">
                   <li>• VPIP: {formatStatPercentage(stats.vpip)}</li>
                   <li>• PFR: {formatStatPercentage(stats.pfr)}</li>
@@ -197,7 +197,7 @@ export function PerformanceChartCard({ playerId }: PerformanceChartCardProps) {
                 </ul>
               </div>
               <div>
-                <p className="font-medium mb-1 text-gray-900 dark:text-gray-100">권장 범위</p>
+                <p className="font-medium mb-1 text-foreground">권장 범위</p>
                 <ul className="space-y-1">
                   <li>• VPIP: 20-30%</li>
                   <li>• PFR: 15-25%</li>

--- a/components/features/player/stats/PositionalStatsCard.tsx
+++ b/components/features/player/stats/PositionalStatsCard.tsx
@@ -137,7 +137,7 @@ export function PositionalStatsCard({ playerId }: PositionalStatsCardProps) {
           </TableBody>
         </Table>
 
-        <div className="mt-4 text-xs text-gray-600 dark:text-gray-400">
+        <div className="mt-4 text-xs text-muted-foreground">
           <p>• VPIP: 자발적 팟 참여율</p>
           <p>• PFR: 프리플롭 레이즈율</p>
           <p>• 승률: 해당 포지션에서 승리한 핸드 비율</p>

--- a/components/features/player/stats/PositionalStatsCard.tsx
+++ b/components/features/player/stats/PositionalStatsCard.tsx
@@ -67,7 +67,7 @@ export function PositionalStatsCard({ playerId }: PositionalStatsCardProps) {
   const isPremium = posStats.length >= 5 // 5개 이상 포지션 데이터
 
   return (
-    <Card className={isPremium ? 'border-gold-500/50 bg-gradient-to-br from-gray-800 to-gray-900' : undefined}>
+    <Card className={isPremium ? 'border-gold-500/50 bg-gradient-to-br from-muted to-background' : undefined}>
       <CardHeader>
         <CardTitle className={isPremium ? 'bg-gradient-to-r from-gold-400 to-gold-600 bg-clip-text text-transparent' : undefined}>
           포지션별 통계

--- a/components/features/poker/Card.tsx
+++ b/components/features/poker/Card.tsx
@@ -36,14 +36,14 @@ export function Card({ card, className, size = 'md' }: CardProps) {
     return (
       <div
         className={cn(
-          'bg-gray-700 border border-gray-600 rounded flex items-center justify-center',
+          'bg-muted border border-border rounded flex items-center justify-center',
           size === 'sm' && 'w-8 h-12 text-xs',
           size === 'md' && 'w-12 h-16 text-sm',
           size === 'lg' && 'w-16 h-24 text-base',
           className
         )}
       >
-        <span className="text-gray-500">?</span>
+        <span className="text-muted-foreground">?</span>
       </div>
     )
   }
@@ -57,8 +57,8 @@ export function Card({ card, className, size = 'md' }: CardProps) {
   return (
     <div
       className={cn(
-        'bg-white border-2 rounded flex flex-col items-center justify-center font-bold shadow-md',
-        isRed ? 'text-red-600 border-red-200' : 'text-gray-900 border-gray-200',
+        'bg-white dark:bg-card border-2 rounded flex flex-col items-center justify-center font-bold shadow-md',
+        isRed ? 'text-red-600 border-red-200' : 'text-foreground border-border',
         size === 'sm' && 'w-8 h-12 text-xs',
         size === 'md' && 'w-12 h-16 text-sm',
         size === 'lg' && 'w-16 h-24 text-base',

--- a/components/features/poker/PlayerSeat.tsx
+++ b/components/features/poker/PlayerSeat.tsx
@@ -49,7 +49,7 @@ export function PlayerSeat({
         'relative flex flex-col items-center gap-2 p-3 rounded-lg border-2 transition-all',
         highlighted
           ? 'border-yellow-500 bg-yellow-50 dark:bg-yellow-950/20 shadow-lg'
-          : 'border-gray-300 dark:border-gray-700 bg-card',
+          : 'border-border bg-card',
         player.isWinner &&
           'ring-2 ring-green-500 border-green-500 bg-green-50 dark:bg-green-950/20',
         className

--- a/components/features/poker/PokerTable.tsx
+++ b/components/features/poker/PokerTable.tsx
@@ -54,7 +54,7 @@ export function PokerTable({
 
   if (totalSeats === 0) {
     return (
-      <div className="w-full aspect-[16/10] flex items-center justify-center border-2 border-dashed border-gray-300 dark:border-gray-700 rounded-lg">
+      <div className="w-full aspect-[16/10] flex items-center justify-center border-2 border-dashed border-border rounded-lg">
         <p className="text-muted-foreground">No players in this hand</p>
       </div>
     )

--- a/components/features/video/SegmentManager.tsx
+++ b/components/features/video/SegmentManager.tsx
@@ -22,8 +22,8 @@ const SEGMENT_TYPES: Record<SegmentType, { label: string; icon: any; color: stri
   countdown: {
     label: '카운트다운',
     icon: Clock,
-    color: 'text-gray-600 dark:text-gray-400',
-    bgColor: 'bg-gray-100 dark:bg-gray-800'
+    color: 'text-muted-foreground',
+    bgColor: 'bg-muted'
   },
   opening: {
     label: '오프닝',

--- a/components/features/video/upload/UploadProgress.tsx
+++ b/components/features/video/upload/UploadProgress.tsx
@@ -112,17 +112,17 @@ export function UploadProgress({
   return (
     <div
       className={cn(
-        'rounded-lg border border-gray-700 bg-gray-800 p-6',
+        'rounded-lg border border-border bg-card p-6',
         className
       )}
     >
       {/* Header: 파일명 + 상태 */}
       <div className="flex items-start justify-between gap-4">
         <div className="flex-1 min-w-0">
-          <h3 className="text-lg font-semibold text-gray-100 truncate">
+          <h3 className="text-lg font-semibold text-foreground truncate">
             {fileName}
           </h3>
-          <p className="text-sm text-gray-400 mt-1">
+          <p className="text-sm text-muted-foreground mt-1">
             {formatFileSize(fileSize)}
           </p>
         </div>
@@ -150,12 +150,12 @@ export function UploadProgress({
       {/* Progress Bar */}
       <div className="mt-4">
         <div className="flex items-center justify-between mb-2">
-          <span className="text-sm font-medium text-gray-300">
+          <span className="text-sm font-medium text-foreground">
             {progress}%
           </span>
 
           {status === 'uploading' && (
-            <span className="text-sm text-gray-400">
+            <span className="text-sm text-muted-foreground">
               {formatSpeed(uploadSpeed)}
             </span>
           )}
@@ -165,7 +165,7 @@ export function UploadProgress({
 
         {/* 남은 시간 */}
         {status === 'uploading' && remainingTime > 0 && (
-          <p className="text-xs text-gray-500 mt-2">
+          <p className="text-xs text-muted-foreground mt-2">
             남은 시간: {formatTime(remainingTime)}
           </p>
         )}

--- a/components/features/video/upload/VideoUploader.tsx
+++ b/components/features/video/upload/VideoUploader.tsx
@@ -187,7 +187,7 @@ export function VideoUploader({
           'cursor-pointer',
           isDragging
             ? 'border-gold-500 bg-gold-500/10'
-            : 'border-gray-600 bg-gray-800/50 hover:border-gold-600 hover:bg-gray-800',
+            : 'border-border bg-muted/50 hover:border-gold-600 hover:bg-muted',
           disabled && 'cursor-not-allowed opacity-50'
         )}
       >
@@ -195,26 +195,26 @@ export function VideoUploader({
         <div
           className={cn(
             'rounded-full p-4 transition-colors',
-            isDragging ? 'bg-gold-500/20' : 'bg-gray-700'
+            isDragging ? 'bg-gold-500/20' : 'bg-muted'
           )}
         >
           <Upload
             className={cn(
               'h-12 w-12 transition-colors',
-              isDragging ? 'text-gold-400' : 'text-gray-400'
+              isDragging ? 'text-gold-400' : 'text-muted-foreground'
             )}
           />
         </div>
 
         {/* 메시지 */}
         <div className="text-center">
-          <p className="text-lg font-medium text-gray-200">
+          <p className="text-lg font-medium text-foreground">
             {isDragging
               ? '파일을 놓아주세요'
               : '영상 파일을 드래그하거나 클릭하여 선택하세요'}
           </p>
 
-          <div className="mt-3 space-y-1 text-sm text-gray-400">
+          <div className="mt-3 space-y-1 text-sm text-muted-foreground">
             <p>지원 형식: {ACCEPTED_FORMATS.join(', ')}</p>
             <p>최대 크기: 50GB</p>
           </div>

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -67,8 +67,8 @@ export function Header() {
 
   return (
     <>
-      {/* Flowbite Navbar - Dark Mode */}
-      <nav className="sticky top-0 z-[100] w-full border-b-[3px] border-gold-500 bg-gray-900" role="banner">
+      {/* Flowbite Navbar */}
+      <nav className="sticky top-0 z-[100] w-full border-b-[3px] border-gold-500 bg-background" role="banner">
         <div className="w-full px-6 h-16 flex items-center justify-between">
           {/* Left: Logo + Navigation Menu */}
           <div className="flex items-center gap-8">
@@ -99,7 +99,7 @@ export function Header() {
                   <button
                     type="button"
                     data-testid="login-button"
-                    className="hidden md:inline-flex text-gray-100 bg-transparent border border-gray-600 hover:bg-gray-800 focus:ring-4 focus:outline-none focus:ring-gray-700 font-medium rounded-lg text-sm px-4 py-2 transition-colors"
+                    className="hidden md:inline-flex text-foreground bg-transparent border border-border hover:bg-muted focus:ring-4 focus:outline-none focus:ring-ring font-medium rounded-lg text-sm px-4 py-2 transition-colors"
                     onClick={() => router.push("/auth/login")}
                   >
                     LOGIN
@@ -111,7 +111,7 @@ export function Header() {
             {/* Mobile Menu Toggle Button */}
             <button
               type="button"
-              className="md:hidden inline-flex items-center p-2 w-9 h-9 justify-center text-gray-400 rounded-lg hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-700 transition-colors"
+              className="md:hidden inline-flex items-center p-2 w-9 h-9 justify-center text-muted-foreground rounded-lg hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring transition-colors"
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
               aria-label="Toggle navigation"
               aria-controls="mobile-menu"

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -10,6 +10,7 @@ import { HeaderLogo } from "./HeaderLogo"
 import { HeaderDesktopNav } from "./HeaderDesktopNav"
 import { HeaderUserMenu } from "./HeaderUserMenu"
 import { HeaderMobileMenu } from "./HeaderMobileMenu"
+import { ThemeToggle } from "./ThemeToggle"
 import type { NavLink } from "./HeaderDesktopNav"
 
 export function Header() {
@@ -75,8 +76,9 @@ export function Header() {
             <HeaderDesktopNav navLinks={navLinks} />
           </div>
 
-          {/* Right: Notification, Profile */}
+          {/* Right: Theme Toggle, Notification, Profile */}
           <div className="flex items-center gap-3">
+            <ThemeToggle />
             <NotificationBell />
 
             {/* Login/Profile UI */}

--- a/components/header/HeaderDesktopNav.tsx
+++ b/components/header/HeaderDesktopNav.tsx
@@ -38,7 +38,7 @@ export function HeaderDesktopNav({ navLinks }: HeaderDesktopNavProps) {
             >
               <div className={cn(
                 "text-sm font-bold uppercase tracking-wide transition-colors hover:text-gold-400 relative inline-flex items-center gap-1 cursor-pointer",
-                isActive ? "text-gold-400" : "text-gray-300"
+                isActive ? "text-gold-400" : "text-foreground"
               )}>
                 {link.label}
                 <ChevronRight className={cn(
@@ -58,7 +58,7 @@ export function HeaderDesktopNav({ navLinks }: HeaderDesktopNavProps) {
                     animate={{ opacity: 1, width: "auto", x: 0 }}
                     exit={{ opacity: 0, width: 0, x: -10 }}
                     transition={{ duration: 0.3, ease: "easeInOut" }}
-                    className="ml-2 flex items-center gap-3 bg-gray-800 border-2 border-gold-500 rounded-lg shadow-lg px-4 py-2 whitespace-nowrap"
+                    className="ml-2 flex items-center gap-3 bg-muted border-2 border-gold-500 rounded-lg shadow-lg px-4 py-2 whitespace-nowrap"
                   >
                     {link.subItems.map((subItem) => {
                       const subIsActive = pathname === subItem.href ||
@@ -71,7 +71,7 @@ export function HeaderDesktopNav({ navLinks }: HeaderDesktopNavProps) {
                             "text-sm font-semibold uppercase tracking-wide transition-colors hover:text-gold-400",
                             subIsActive
                               ? "text-gold-400"
-                              : "text-gray-300"
+                              : "text-foreground"
                           )}
                         >
                           {subItem.label}
@@ -97,7 +97,7 @@ export function HeaderDesktopNav({ navLinks }: HeaderDesktopNavProps) {
               "text-sm font-bold uppercase tracking-wide transition-colors hover:text-gold-400 relative",
               isActive
                 ? "text-gold-400"
-                : "text-gray-300"
+                : "text-foreground"
             )}
           >
             {link.label}

--- a/components/header/HeaderMobileMenu.tsx
+++ b/components/header/HeaderMobileMenu.tsx
@@ -63,7 +63,7 @@ export function HeaderMobileMenu({
   return (
     <div
       id="mobile-menu"
-      className="md:hidden border-b border-gray-700 bg-gray-900"
+      className="md:hidden border-b border-border bg-background"
     >
       <div className="w-full px-4 py-4 space-y-2">
         {/* Navigation Links */}
@@ -81,7 +81,7 @@ export function HeaderMobileMenu({
                     "w-full flex items-center justify-between px-4 py-2 rounded-lg text-sm font-medium transition-colors",
                     isActive
                       ? "bg-gold-900/20 text-gold-400"
-                      : "text-gray-300 hover:bg-gray-800 hover:text-gray-100"
+                      : "text-foreground hover:bg-muted hover:text-foreground"
                   )}
                 >
                   <span>{link.label}</span>
@@ -113,7 +113,7 @@ export function HeaderMobileMenu({
                                 "block px-4 py-2 rounded-lg text-sm font-medium transition-colors",
                                 subIsActive
                                   ? "bg-gold-900/20 text-gold-400"
-                                  : "text-gray-400 hover:bg-gray-800 hover:text-gray-100"
+                                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
                               )}
                             >
                               {subItem.label}
@@ -140,7 +140,7 @@ export function HeaderMobileMenu({
                 "block px-4 py-2 rounded-lg text-sm font-medium transition-colors",
                 isActive
                   ? "bg-gold-900/20 text-gold-400"
-                  : "text-gray-300 hover:bg-gray-800 hover:text-gray-100"
+                  : "text-foreground hover:bg-muted hover:text-foreground"
               )}
             >
               {link.label}
@@ -150,8 +150,8 @@ export function HeaderMobileMenu({
 
         {/* Theme Section */}
         {mounted && (
-          <div className="mt-4 pt-4 border-t border-gray-700">
-            <div className="px-4 py-2 text-xs text-gray-500 font-semibold uppercase tracking-wider">
+          <div className="mt-4 pt-4 border-t border-border">
+            <div className="px-4 py-2 text-xs text-muted-foreground font-semibold uppercase tracking-wider">
               테마 설정
             </div>
             <div className="flex gap-2 px-4 py-2">
@@ -161,7 +161,7 @@ export function HeaderMobileMenu({
                   "flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors",
                   theme === "light"
                     ? "bg-gold-500 text-gray-900"
-                    : "text-gray-300 hover:bg-gray-800"
+                    : "text-foreground hover:bg-muted"
                 )}
               >
                 <Sun className="h-4 w-4" />
@@ -173,7 +173,7 @@ export function HeaderMobileMenu({
                   "flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors",
                   theme === "dark"
                     ? "bg-gold-500 text-gray-900"
-                    : "text-gray-300 hover:bg-gray-800"
+                    : "text-foreground hover:bg-muted"
                 )}
               >
                 <Moon className="h-4 w-4" />
@@ -185,7 +185,7 @@ export function HeaderMobileMenu({
                   "flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors",
                   theme === "system"
                     ? "bg-gold-500 text-gray-900"
-                    : "text-gray-300 hover:bg-gray-800"
+                    : "text-foreground hover:bg-muted"
                 )}
               >
                 <Monitor className="h-4 w-4" />
@@ -199,7 +199,7 @@ export function HeaderMobileMenu({
         {!authLoading && (
           <>
             {user ? (
-              <div className="mt-4 pt-4 border-t border-gray-700 space-y-2">
+              <div className="mt-4 pt-4 border-t border-border space-y-2">
                 {/* User Info */}
                 <div className="px-4 py-2">
                   <div className="flex items-center gap-3">
@@ -215,10 +215,10 @@ export function HeaderMobileMenu({
                       </div>
                     )}
                     <div className="flex flex-col">
-                      <p className="text-sm font-medium text-gray-100">
+                      <p className="text-sm font-medium text-foreground">
                         {displayName}
                       </p>
-                      <p className="text-xs text-gray-400 truncate">
+                      <p className="text-xs text-muted-foreground truncate">
                         {user.email}
                       </p>
                     </div>
@@ -231,7 +231,7 @@ export function HeaderMobileMenu({
                     router.push("/profile")
                     onClose()
                   }}
-                  className="w-full flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-gray-800 rounded-lg transition-colors"
+                  className="w-full flex items-center px-4 py-2 text-sm text-foreground hover:bg-muted rounded-lg transition-colors"
                 >
                   <User className="mr-2 h-4 w-4" />
                   Profile
@@ -241,7 +241,7 @@ export function HeaderMobileMenu({
                     router.push("/bookmarks")
                     onClose()
                   }}
-                  className="w-full flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-gray-800 rounded-lg transition-colors"
+                  className="w-full flex items-center px-4 py-2 text-sm text-foreground hover:bg-muted rounded-lg transition-colors"
                 >
                   <Bookmark className="mr-2 h-4 w-4" />
                   Bookmarks
@@ -250,7 +250,7 @@ export function HeaderMobileMenu({
                 {/* Reporter Menu */}
                 {isUserReporter && (
                   <>
-                    <div className="px-4 py-2 text-xs text-gray-500 font-semibold uppercase tracking-wider">
+                    <div className="px-4 py-2 text-xs text-muted-foreground font-semibold uppercase tracking-wider">
                       Reporter Menu
                     </div>
                     <button
@@ -258,7 +258,7 @@ export function HeaderMobileMenu({
                         router.push("/reporter/news")
                         onClose()
                       }}
-                      className="w-full flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-gray-800 rounded-lg transition-colors"
+                      className="w-full flex items-center px-4 py-2 text-sm text-foreground hover:bg-muted rounded-lg transition-colors"
                     >
                       <Newspaper className="mr-2 h-4 w-4" />
                       My News
@@ -268,7 +268,7 @@ export function HeaderMobileMenu({
                         router.push("/reporter/live")
                         onClose()
                       }}
-                      className="w-full flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-gray-800 rounded-lg transition-colors"
+                      className="w-full flex items-center px-4 py-2 text-sm text-foreground hover:bg-muted rounded-lg transition-colors"
                     >
                       <Radio className="mr-2 h-4 w-4" />
                       My Live Reports
@@ -279,7 +279,7 @@ export function HeaderMobileMenu({
                 {/* Admin Menu */}
                 {isUserAdmin && (
                   <>
-                    <div className="px-4 py-2 text-xs text-gray-500 font-semibold uppercase tracking-wider">
+                    <div className="px-4 py-2 text-xs text-muted-foreground font-semibold uppercase tracking-wider">
                       Admin Menu
                     </div>
                     <button
@@ -287,7 +287,7 @@ export function HeaderMobileMenu({
                         router.push("/admin/dashboard")
                         onClose()
                       }}
-                      className="w-full flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-gray-800 rounded-lg transition-colors"
+                      className="w-full flex items-center px-4 py-2 text-sm text-foreground hover:bg-muted rounded-lg transition-colors"
                     >
                       <LayoutDashboard className="mr-2 h-4 w-4" />
                       Dashboard
@@ -297,7 +297,7 @@ export function HeaderMobileMenu({
                         router.push("/admin/users")
                         onClose()
                       }}
-                      className="w-full flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-gray-800 rounded-lg transition-colors"
+                      className="w-full flex items-center px-4 py-2 text-sm text-foreground hover:bg-muted rounded-lg transition-colors"
                     >
                       <Users className="mr-2 h-4 w-4" />
                       Users
@@ -307,7 +307,7 @@ export function HeaderMobileMenu({
                         router.push("/admin/claims")
                         onClose()
                       }}
-                      className="w-full flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-gray-800 rounded-lg transition-colors"
+                      className="w-full flex items-center px-4 py-2 text-sm text-foreground hover:bg-muted rounded-lg transition-colors"
                     >
                       <Shield className="mr-2 h-4 w-4" />
                       Claims
@@ -317,7 +317,7 @@ export function HeaderMobileMenu({
                         router.push("/admin/content")
                         onClose()
                       }}
-                      className="w-full flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-gray-800 rounded-lg transition-colors"
+                      className="w-full flex items-center px-4 py-2 text-sm text-foreground hover:bg-muted rounded-lg transition-colors"
                     >
                       <FileText className="mr-2 h-4 w-4" />
                       Content
@@ -327,7 +327,7 @@ export function HeaderMobileMenu({
                         router.push("/admin/edit-requests")
                         onClose()
                       }}
-                      className="w-full flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-gray-800 rounded-lg transition-colors"
+                      className="w-full flex items-center px-4 py-2 text-sm text-foreground hover:bg-muted rounded-lg transition-colors"
                     >
                       <Edit className="mr-2 h-4 w-4" />
                       Edit Requests
@@ -337,7 +337,7 @@ export function HeaderMobileMenu({
                         router.push("/admin/archive")
                         onClose()
                       }}
-                      className="w-full flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-gray-800 rounded-lg transition-colors"
+                      className="w-full flex items-center px-4 py-2 text-sm text-foreground hover:bg-muted rounded-lg transition-colors"
                     >
                       <Archive className="mr-2 h-4 w-4" />
                       Archive
@@ -347,7 +347,7 @@ export function HeaderMobileMenu({
                         router.push("/admin/categories")
                         onClose()
                       }}
-                      className="w-full flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-gray-800 rounded-lg transition-colors"
+                      className="w-full flex items-center px-4 py-2 text-sm text-foreground hover:bg-muted rounded-lg transition-colors"
                     >
                       <Folder className="mr-2 h-4 w-4" />
                       Categories
@@ -358,7 +358,7 @@ export function HeaderMobileMenu({
                 {/* Logout */}
                 <button
                   onClick={handleSignOut}
-                  className="w-full flex items-center px-4 py-2 text-sm text-gray-300 hover:bg-gray-800 rounded-lg transition-colors"
+                  className="w-full flex items-center px-4 py-2 text-sm text-foreground hover:bg-muted rounded-lg transition-colors"
                 >
                   <LogOut className="mr-2 h-4 w-4" />
                   Logout
@@ -370,7 +370,7 @@ export function HeaderMobileMenu({
                   router.push("/auth/login")
                   onClose()
                 }}
-                className="w-full mt-4 text-gray-100 bg-transparent border border-gray-600 hover:bg-gray-800 focus:ring-4 focus:outline-none focus:ring-gray-700 font-medium rounded-lg text-sm px-4 py-2 transition-colors"
+                className="w-full mt-4 text-foreground bg-transparent border border-border hover:bg-muted focus:ring-4 focus:outline-none focus:ring-border font-medium rounded-lg text-sm px-4 py-2 transition-colors"
               >
                 LOGIN
               </button>

--- a/components/header/HeaderMobileMenu.tsx
+++ b/components/header/HeaderMobileMenu.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
+import { useTheme } from "next-themes"
 import { cn } from "@/lib/utils"
-import { User, LogOut, Shield, Users, LayoutDashboard, FileText, Edit, Bookmark, ChevronDown, Newspaper, Radio, Folder, Archive } from "lucide-react"
+import { User, LogOut, Shield, Users, LayoutDashboard, FileText, Edit, Bookmark, ChevronDown, Newspaper, Radio, Folder, Archive, Sun, Moon, Monitor } from "lucide-react"
 import { motion, AnimatePresence } from "framer-motion"
 import type { AuthUser } from "@/lib/auth"
 import type { UserProfile } from "@/lib/user-profile"
@@ -41,6 +42,12 @@ export function HeaderMobileMenu({
   const pathname = usePathname()
   const router = useRouter()
   const [archiveExpandedMobile, setArchiveExpandedMobile] = useState(false)
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
 
   if (!isOpen) return null
 
@@ -140,6 +147,53 @@ export function HeaderMobileMenu({
             </Link>
           )
         })}
+
+        {/* Theme Section */}
+        {mounted && (
+          <div className="mt-4 pt-4 border-t border-gray-700">
+            <div className="px-4 py-2 text-xs text-gray-500 font-semibold uppercase tracking-wider">
+              테마 설정
+            </div>
+            <div className="flex gap-2 px-4 py-2">
+              <button
+                onClick={() => setTheme("light")}
+                className={cn(
+                  "flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors",
+                  theme === "light"
+                    ? "bg-gold-500 text-gray-900"
+                    : "text-gray-300 hover:bg-gray-800"
+                )}
+              >
+                <Sun className="h-4 w-4" />
+                라이트
+              </button>
+              <button
+                onClick={() => setTheme("dark")}
+                className={cn(
+                  "flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors",
+                  theme === "dark"
+                    ? "bg-gold-500 text-gray-900"
+                    : "text-gray-300 hover:bg-gray-800"
+                )}
+              >
+                <Moon className="h-4 w-4" />
+                다크
+              </button>
+              <button
+                onClick={() => setTheme("system")}
+                className={cn(
+                  "flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors",
+                  theme === "system"
+                    ? "bg-gold-500 text-gray-900"
+                    : "text-gray-300 hover:bg-gray-800"
+                )}
+              >
+                <Monitor className="h-4 w-4" />
+                시스템
+              </button>
+            </div>
+          </div>
+        )}
 
         {/* User Section */}
         {!authLoading && (

--- a/components/header/HeaderUserMenu.tsx
+++ b/components/header/HeaderUserMenu.tsx
@@ -89,7 +89,7 @@ export function HeaderUserMenu({
       <button
         id="user-menu-button"
         type="button"
-        className="flex text-sm bg-gray-800 rounded-full focus:ring-4 focus:ring-gray-700 transition-all hover:ring-2 hover:ring-gray-600"
+        className="flex text-sm bg-muted rounded-full focus:ring-4 focus:ring-border transition-all hover:ring-2 hover:ring-border"
         aria-expanded="false"
       >
         <span className="sr-only">Open user menu</span>
@@ -101,7 +101,7 @@ export function HeaderUserMenu({
           />
         ) : (
           <div className="w-8 h-8 rounded-full bg-gold-500 flex items-center justify-center">
-            <span className="text-sm font-semibold text-gray-900">{initials}</span>
+            <span className="text-sm font-semibold text-background">{initials}</span>
           </div>
         )}
       </button>
@@ -109,20 +109,20 @@ export function HeaderUserMenu({
       {/* Dropdown Menu */}
       <div
         id="user-menu-dropdown"
-        className="z-50 hidden bg-gray-800 divide-y divide-gray-700 rounded-lg shadow-lg w-56 border border-gray-700"
+        className="z-50 hidden bg-muted divide-y divide-border rounded-lg shadow-lg w-56 border border-border"
       >
         {/* User Info */}
         <div className="px-4 py-3">
-          <span className="block text-sm text-gray-100 font-medium">{displayName}</span>
-          <span className="block text-xs text-gray-400 truncate">{user.email}</span>
+          <span className="block text-sm text-foreground font-medium">{displayName}</span>
+          <span className="block text-xs text-muted-foreground truncate">{user.email}</span>
         </div>
 
         {/* Main Menu */}
-        <ul className="py-2 text-sm text-gray-200">
+        <ul className="py-2 text-sm text-foreground">
           <li>
             <button
               onClick={() => router.push("/profile")}
-              className="w-full flex items-center px-4 py-2 hover:bg-gray-700 transition-colors text-left"
+              className="w-full flex items-center px-4 py-2 hover:bg-muted transition-colors text-left"
             >
               <User className="mr-2 h-4 w-4" />
               Profile
@@ -131,7 +131,7 @@ export function HeaderUserMenu({
           <li>
             <button
               onClick={() => router.push("/bookmarks")}
-              className="w-full flex items-center px-4 py-2 hover:bg-gray-700 transition-colors text-left"
+              className="w-full flex items-center px-4 py-2 hover:bg-muted transition-colors text-left"
             >
               <Bookmark className="mr-2 h-4 w-4" />
               Bookmarks
@@ -143,15 +143,15 @@ export function HeaderUserMenu({
         {isUserReporter && (
           <>
             <div className="px-4 py-2">
-              <span className="block text-xs text-gray-500 uppercase font-semibold tracking-wider">
+              <span className="block text-xs text-muted-foreground uppercase font-semibold tracking-wider">
                 Reporter Menu
               </span>
             </div>
-            <ul className="py-2 text-sm text-gray-200">
+            <ul className="py-2 text-sm text-foreground">
               <li>
                 <button
                   onClick={() => router.push("/reporter/news")}
-                  className="w-full flex items-center px-4 py-2 hover:bg-gray-700 transition-colors text-left"
+                  className="w-full flex items-center px-4 py-2 hover:bg-muted transition-colors text-left"
                 >
                   <Newspaper className="mr-2 h-4 w-4" />
                   My News
@@ -160,7 +160,7 @@ export function HeaderUserMenu({
               <li>
                 <button
                   onClick={() => router.push("/reporter/live")}
-                  className="w-full flex items-center px-4 py-2 hover:bg-gray-700 transition-colors text-left"
+                  className="w-full flex items-center px-4 py-2 hover:bg-muted transition-colors text-left"
                 >
                   <Radio className="mr-2 h-4 w-4" />
                   My Live Reports
@@ -174,15 +174,15 @@ export function HeaderUserMenu({
         {isUserAdmin && (
           <>
             <div className="px-4 py-2">
-              <span className="block text-xs text-gray-500 uppercase font-semibold tracking-wider">
+              <span className="block text-xs text-muted-foreground uppercase font-semibold tracking-wider">
                 Admin Menu
               </span>
             </div>
-            <ul className="py-2 text-sm text-gray-200">
+            <ul className="py-2 text-sm text-foreground">
               <li>
                 <button
                   onClick={() => router.push("/admin/dashboard")}
-                  className="w-full flex items-center px-4 py-2 hover:bg-gray-700 transition-colors text-left"
+                  className="w-full flex items-center px-4 py-2 hover:bg-muted transition-colors text-left"
                 >
                   <LayoutDashboard className="mr-2 h-4 w-4" />
                   Dashboard
@@ -191,7 +191,7 @@ export function HeaderUserMenu({
               <li>
                 <button
                   onClick={() => router.push("/admin/users")}
-                  className="w-full flex items-center px-4 py-2 hover:bg-gray-700 transition-colors text-left"
+                  className="w-full flex items-center px-4 py-2 hover:bg-muted transition-colors text-left"
                 >
                   <Users className="mr-2 h-4 w-4" />
                   Users
@@ -200,7 +200,7 @@ export function HeaderUserMenu({
               <li>
                 <button
                   onClick={() => router.push("/admin/claims")}
-                  className="w-full flex items-center px-4 py-2 hover:bg-gray-700 transition-colors text-left"
+                  className="w-full flex items-center px-4 py-2 hover:bg-muted transition-colors text-left"
                 >
                   <Shield className="mr-2 h-4 w-4" />
                   Claims
@@ -209,7 +209,7 @@ export function HeaderUserMenu({
               <li>
                 <button
                   onClick={() => router.push("/admin/content")}
-                  className="w-full flex items-center px-4 py-2 hover:bg-gray-700 transition-colors text-left"
+                  className="w-full flex items-center px-4 py-2 hover:bg-muted transition-colors text-left"
                 >
                   <FileText className="mr-2 h-4 w-4" />
                   Content
@@ -218,7 +218,7 @@ export function HeaderUserMenu({
               <li>
                 <button
                   onClick={() => router.push("/admin/edit-requests")}
-                  className="w-full flex items-center px-4 py-2 hover:bg-gray-700 transition-colors text-left"
+                  className="w-full flex items-center px-4 py-2 hover:bg-muted transition-colors text-left"
                 >
                   <Edit className="mr-2 h-4 w-4" />
                   Edit Requests
@@ -227,7 +227,7 @@ export function HeaderUserMenu({
               <li>
                 <button
                   onClick={() => router.push("/admin/archive")}
-                  className="w-full flex items-center px-4 py-2 hover:bg-gray-700 transition-colors text-left"
+                  className="w-full flex items-center px-4 py-2 hover:bg-muted transition-colors text-left"
                 >
                   <Archive className="mr-2 h-4 w-4" />
                   Archive
@@ -236,7 +236,7 @@ export function HeaderUserMenu({
               <li>
                 <button
                   onClick={() => router.push("/admin/categories")}
-                  className="w-full flex items-center px-4 py-2 hover:bg-gray-700 transition-colors text-left"
+                  className="w-full flex items-center px-4 py-2 hover:bg-muted transition-colors text-left"
                 >
                   <Folder className="mr-2 h-4 w-4" />
                   Categories
@@ -247,11 +247,11 @@ export function HeaderUserMenu({
         )}
 
         {/* Logout */}
-        <ul className="py-2 text-sm text-gray-200">
+        <ul className="py-2 text-sm text-foreground">
           <li>
             <button
               onClick={onSignOut}
-              className="w-full flex items-center px-4 py-2 hover:bg-gray-700 transition-colors text-left"
+              className="w-full flex items-center px-4 py-2 hover:bg-muted transition-colors text-left"
             >
               <LogOut className="mr-2 h-4 w-4" />
               Logout

--- a/components/header/ThemeToggle.tsx
+++ b/components/header/ThemeToggle.tsx
@@ -1,0 +1,94 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useTheme } from "next-themes"
+import { Sun, Moon, Monitor } from "lucide-react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+type ThemeValue = "light" | "dark" | "system"
+
+interface ThemeOption {
+  value: ThemeValue
+  label: string
+  icon: React.ReactNode
+}
+
+export function ThemeToggle() {
+  const [mounted, setMounted] = useState(false)
+  const { theme, setTheme, resolvedTheme } = useTheme()
+
+  // SSR hydration 이슈 방지
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // mounted 전에는 placeholder 렌더링 (hydration mismatch 방지)
+  if (!mounted) {
+    return (
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-9 w-9 text-muted-foreground"
+        aria-label="테마 변경"
+      >
+        <Sun className="h-5 w-5" />
+      </Button>
+    )
+  }
+
+  const themeOptions: ThemeOption[] = [
+    { value: "light", label: "라이트", icon: <Sun className="h-4 w-4" /> },
+    { value: "dark", label: "다크", icon: <Moon className="h-4 w-4" /> },
+    { value: "system", label: "시스템", icon: <Monitor className="h-4 w-4" /> },
+  ]
+
+  // 현재 표시할 아이콘 결정
+  const getCurrentIcon = () => {
+    if (theme === "system") {
+      return resolvedTheme === "dark"
+        ? <Moon className="h-5 w-5" />
+        : <Sun className="h-5 w-5" />
+    }
+    return theme === "dark"
+      ? <Moon className="h-5 w-5" />
+      : <Sun className="h-5 w-5" />
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-9 w-9 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+          aria-label="테마 변경"
+        >
+          {getCurrentIcon()}
+          <span className="sr-only">테마 변경</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-[120px]">
+        {themeOptions.map((option) => (
+          <DropdownMenuItem
+            key={option.value}
+            onClick={() => setTheme(option.value)}
+            className={cn(
+              "flex items-center gap-2 cursor-pointer",
+              theme === option.value && "bg-accent text-accent-foreground"
+            )}
+          >
+            {option.icon}
+            <span>{option.label}</span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/components/home/HeroSection.tsx
+++ b/components/home/HeroSection.tsx
@@ -5,7 +5,7 @@ export function HeroSection() {
   return (
     <section className="relative py-20 md:py-32 overflow-hidden">
       {/* Background with gold glow effect */}
-      <div className="absolute inset-0 bg-gradient-to-b from-gray-800/50 to-gray-900" />
+      <div className="absolute inset-0 bg-gradient-to-b from-muted/50 to-background" />
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-gold-400/10 via-transparent to-transparent" />
 
       {/* Grid pattern overlay */}
@@ -29,9 +29,9 @@ export function HeroSection() {
           <div className="space-y-4">
             <h1 className="text-5xl md:text-7xl font-bold tracking-tight">
               <span className="text-gold-400">TEMPLAR</span>{' '}
-              <span className="text-gray-50">ARCHIVES</span>
+              <span className="text-foreground">ARCHIVES</span>
             </h1>
-            <p className="text-xl md:text-2xl text-gray-400 max-w-2xl mx-auto">
+            <p className="text-xl md:text-2xl text-muted-foreground max-w-2xl mx-auto">
               프로 포커 토너먼트의 모든 핸드 히스토리를 분석하고 학습하세요
             </p>
           </div>
@@ -61,7 +61,7 @@ export function HeroSection() {
             </Link>
             <Link
               href="/search"
-              className="px-8 py-4 bg-gray-800 text-gray-50 font-bold text-lg rounded-lg hover:bg-gray-700 transition-all duration-300 border border-gray-700 hover:border-gold-400/50"
+              className="px-8 py-4 bg-muted text-foreground font-bold text-lg rounded-lg hover:bg-muted transition-all duration-300 border border-border hover:border-gold-400/50"
             >
               핸드 검색하기
             </Link>
@@ -72,7 +72,7 @@ export function HeroSection() {
             {['AI 영상 분석', 'GTO 분석', '실시간 통계'].map((feature) => (
               <span
                 key={feature}
-                className="px-4 py-2 bg-gray-800/80 text-gray-400 text-sm rounded-full border border-gray-700/50 backdrop-blur-sm"
+                className="px-4 py-2 bg-muted/80 text-muted-foreground text-sm rounded-full border border-border/50 backdrop-blur-sm"
               >
                 {feature}
               </span>

--- a/components/home/HighlightsSection.tsx
+++ b/components/home/HighlightsSection.tsx
@@ -12,14 +12,14 @@ export function HighlightsSection({ highlights }: HighlightsSectionProps) {
   }
 
   return (
-    <section className="py-12 md:py-16 bg-gray-900">
+    <section className="py-12 md:py-16 bg-background">
       <div className="container max-w-7xl mx-auto px-4 md:px-6">
         {/* Section Header */}
         <div className="flex items-center gap-3 mb-8">
           <TrendingUp className="w-6 h-6 text-gold-400" />
           <div>
-            <h2 className="text-3xl font-bold text-gray-50">주간 하이라이트</h2>
-            <p className="text-gray-400 mt-1">
+            <h2 className="text-3xl font-bold text-foreground">주간 하이라이트</h2>
+            <p className="text-muted-foreground mt-1">
               최근 7일간 가장 많은 좋아요를 받은 핸드
             </p>
           </div>
@@ -38,9 +38,9 @@ export function HighlightsSection({ highlights }: HighlightsSectionProps) {
 
 function HighlightCard({ hand }: { hand: WeeklyHighlight }) {
   return (
-    <div className="group bg-gray-800 border border-gray-700 rounded-lg overflow-hidden hover:border-gold-400/50 transition-all duration-300 hover:shadow-lg hover:shadow-gold-400/10">
+    <div className="group bg-muted border border-border rounded-lg overflow-hidden hover:border-gold-400/50 transition-all duration-300 hover:shadow-lg hover:shadow-gold-400/10">
       {/* Video Thumbnail */}
-      <div className="relative aspect-video bg-gray-900 overflow-hidden">
+      <div className="relative aspect-video bg-background overflow-hidden">
         {hand.video_url ? (
           <>
             <video
@@ -48,22 +48,22 @@ function HighlightCard({ hand }: { hand: WeeklyHighlight }) {
               className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
               preload="metadata"
             />
-            <div className="absolute inset-0 bg-gradient-to-t from-gray-900/80 via-transparent to-transparent" />
+            <div className="absolute inset-0 bg-gradient-to-t from-background/80 via-transparent to-transparent" />
             <div className="absolute inset-0 bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
               <div className="p-4 bg-gold-400 rounded-full">
-                <Play className="w-8 h-8 text-gray-900 fill-current" />
+                <Play className="w-8 h-8 text-background fill-current" />
               </div>
             </div>
           </>
         ) : (
-          <div className="w-full h-full flex items-center justify-center bg-gray-800">
-            <Play className="w-12 h-12 text-gray-600" />
+          <div className="w-full h-full flex items-center justify-center bg-muted">
+            <Play className="w-12 h-12 text-muted-foreground" />
           </div>
         )}
 
         {/* Hand Number Badge */}
         <div className="absolute top-3 right-3">
-          <span className="px-3 py-1 bg-gold-400 text-gray-900 text-sm font-bold rounded-full">
+          <span className="px-3 py-1 bg-gold-400 text-background text-sm font-bold rounded-full">
             #{hand.number}
           </span>
         </div>
@@ -73,22 +73,22 @@ function HighlightCard({ hand }: { hand: WeeklyHighlight }) {
       <div className="p-6 space-y-4">
         {/* Tournament & Stream */}
         <div className="space-y-1">
-          <p className="text-xs text-gray-500 uppercase tracking-wider">
+          <p className="text-xs text-muted-foreground uppercase tracking-wider">
             {hand.tournament_name}
           </p>
-          <p className="text-sm text-gray-400">{hand.day_name}</p>
+          <p className="text-sm text-muted-foreground">{hand.day_name}</p>
         </div>
 
         {/* Description */}
         {hand.description && (
-          <p className="text-gray-300 line-clamp-2 text-sm leading-relaxed">
+          <p className="text-foreground line-clamp-2 text-sm leading-relaxed">
             {hand.description}
           </p>
         )}
 
         {/* Stats */}
-        <div className="flex items-center justify-between pt-2 border-t border-gray-700">
-          <div className="flex items-center gap-1.5 text-gray-400">
+        <div className="flex items-center justify-between pt-2 border-t border-border">
+          <div className="flex items-center gap-1.5 text-muted-foreground">
             <ThumbsUp className="w-4 h-4" />
             <span className="text-sm font-medium">{hand.likes_count}</span>
           </div>
@@ -102,7 +102,7 @@ function HighlightCard({ hand }: { hand: WeeklyHighlight }) {
         {/* View Button */}
         <Link
           href={`/archive?hand=${hand.id}`}
-          className="block w-full py-3 bg-gray-900 text-gray-50 text-center font-semibold rounded-lg hover:bg-gray-700 transition-colors border border-gray-700 hover:border-gold-400/50"
+          className="block w-full py-3 bg-background text-foreground text-center font-semibold rounded-lg hover:bg-muted transition-colors border border-border hover:border-gold-400/50"
         >
           핸드 보기
         </Link>

--- a/components/home/StatsSection.tsx
+++ b/components/home/StatsSection.tsx
@@ -10,7 +10,7 @@ interface StatsSectionProps {
 
 export function StatsSection({ stats }: StatsSectionProps) {
   return (
-    <section className="py-12 md:py-16 bg-gray-800">
+    <section className="py-12 md:py-16 bg-muted">
       <div className="container max-w-7xl mx-auto px-4 md:px-6">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           <StatCard
@@ -59,7 +59,7 @@ function StatCard({ icon: Icon, label, value }: StatCardProps) {
   }, [value])
 
   return (
-    <div className="group bg-gray-900 border border-gray-700 rounded-lg p-8 hover:border-gold-400/50 transition-all duration-300 hover:shadow-lg hover:shadow-gold-400/10">
+    <div className="group bg-background border border-border rounded-lg p-8 hover:border-gold-400/50 transition-all duration-300 hover:shadow-lg hover:shadow-gold-400/10">
       <div className="flex flex-col items-center gap-4 text-center">
         {/* Icon */}
         <div className="p-4 bg-gold-400/10 rounded-full group-hover:bg-gold-400/20 transition-colors">
@@ -67,12 +67,12 @@ function StatCard({ icon: Icon, label, value }: StatCardProps) {
         </div>
 
         {/* Number */}
-        <div className="text-4xl md:text-5xl font-bold text-gray-50 tabular-nums">
+        <div className="text-4xl md:text-5xl font-bold text-foreground tabular-nums">
           {count.toLocaleString()}
         </div>
 
         {/* Label */}
-        <div className="text-sm md:text-base text-gray-400 font-medium uppercase tracking-wider">
+        <div className="text-sm md:text-base text-muted-foreground font-medium uppercase tracking-wider">
           {label}
         </div>
       </div>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -28,34 +28,34 @@ export function Footer() {
   ]
 
   return (
-    <footer className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
+    <footer className="border-t border-border bg-background">
       <div className="container max-w-7xl mx-auto px-4 md:px-6 py-12">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           {/* Brand */}
           <div className="col-span-1">
             <Link href="/" className="flex items-center gap-2 mb-4">
               <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-gold-400 to-gold-600">
-                <span className="font-mono text-lg font-bold text-white dark:text-gray-900">TA</span>
+                <span className="font-mono text-lg font-bold text-white dark:text-background">TA</span>
               </div>
-              <span className="text-lg font-bold text-gray-900 dark:text-gray-100">Templar Archives Index</span>
+              <span className="text-lg font-bold text-foreground">Templar Archives Index</span>
             </Link>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+            <p className="text-sm text-muted-foreground mb-4">
               The ultimate poker hand history archive. Analyze, learn, and improve your game.
             </p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
+            <p className="text-xs text-muted-foreground">
               © {currentYear} Templar Archives Index. All rights reserved.
             </p>
           </div>
 
           {/* About */}
           <div>
-            <h3 className="font-semibold mb-4 text-gray-900 dark:text-gray-100">About</h3>
+            <h3 className="font-semibold mb-4 text-foreground">About</h3>
             <ul className="space-y-2">
               {aboutLinks.map((link) => (
                 <li key={link.href}>
                   <Link
                     href={link.href}
-                    className="text-sm text-gray-500 dark:text-gray-400 hover:text-gold-400 dark:hover:text-gold-300 transition-colors"
+                    className="text-sm text-muted-foreground hover:text-gold-400 dark:hover:text-gold-300 transition-colors"
                   >
                     {link.label}
                   </Link>
@@ -66,13 +66,13 @@ export function Footer() {
 
           {/* Navigation */}
           <div>
-            <h3 className="font-semibold mb-4 text-gray-900 dark:text-gray-100">Navigation</h3>
+            <h3 className="font-semibold mb-4 text-foreground">Navigation</h3>
             <ul className="space-y-2">
               {navigationLinks.map((link) => (
                 <li key={link.href}>
                   <Link
                     href={link.href}
-                    className="text-sm text-gray-500 dark:text-gray-400 hover:text-gold-400 dark:hover:text-gold-300 transition-colors"
+                    className="text-sm text-muted-foreground hover:text-gold-400 dark:hover:text-gold-300 transition-colors"
                   >
                     {link.label}
                   </Link>
@@ -83,13 +83,13 @@ export function Footer() {
 
           {/* Legal & Resources */}
           <div>
-            <h3 className="font-semibold mb-4 text-gray-900 dark:text-gray-100">Legal & Resources</h3>
+            <h3 className="font-semibold mb-4 text-foreground">Legal & Resources</h3>
             <ul className="space-y-2">
               {legalLinks.map((link) => (
                 <li key={link.href}>
                   <Link
                     href={link.href}
-                    className="text-sm text-gray-500 dark:text-gray-400 hover:text-gold-400 dark:hover:text-gold-300 transition-colors"
+                    className="text-sm text-muted-foreground hover:text-gold-400 dark:hover:text-gold-300 transition-colors"
                   >
                     {link.label}
                   </Link>
@@ -100,7 +100,7 @@ export function Footer() {
                   href="https://github.com/anthropics/claude-code"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-gray-500 dark:text-gray-400 hover:text-gold-400 dark:hover:text-gold-300 transition-colors"
+                  className="text-sm text-muted-foreground hover:text-gold-400 dark:hover:text-gold-300 transition-colors"
                 >
                   GitHub
                 </a>
@@ -108,14 +108,14 @@ export function Footer() {
               <li>
                 <a
                   href="mailto:legal@templararchives.com"
-                  className="text-sm text-gray-500 dark:text-gray-400 hover:text-gold-400 dark:hover:text-gold-300 transition-colors"
+                  className="text-sm text-muted-foreground hover:text-gold-400 dark:hover:text-gold-300 transition-colors"
                 >
                   Contact Legal
                 </a>
               </li>
               <li>
                 <CookieSettingsDialog>
-                  <button className="text-sm text-gray-500 dark:text-gray-400 hover:text-gold-400 dark:hover:text-gold-300 transition-colors text-left">
+                  <button className="text-sm text-muted-foreground hover:text-gold-400 dark:hover:text-gold-300 transition-colors text-left">
                     Cookie Settings
                   </button>
                 </CookieSettingsDialog>
@@ -125,8 +125,8 @@ export function Footer() {
         </div>
 
         {/* Open Source Credits */}
-        <div className="mt-12 pt-8 border-t border-gray-200 dark:border-gray-700">
-          <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
+        <div className="mt-12 pt-8 border-t border-border">
+          <p className="text-xs text-muted-foreground text-center">
             Built with{" "}
             <a href="https://nextjs.org" target="_blank" rel="noopener noreferrer" className="hover:text-gold-400 dark:hover:text-gold-300 transition-colors">
               Next.js

--- a/components/layout/Providers.tsx
+++ b/components/layout/Providers.tsx
@@ -26,8 +26,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
     <QueryClientProvider client={queryClient}>
       <ThemeProvider
         attribute="class"
-        defaultTheme="dark"
-        forcedTheme="dark"
+        defaultTheme="system"
+        enableSystem={true}
+        storageKey="templar-theme"
         disableTransitionOnChange
       >
         <AuthProvider>

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -19,7 +19,7 @@ function AccordionItem({
   return (
     <AccordionPrimitive.Item
       data-slot="accordion-item"
-      className={cn('border-b border-gray-700 last:border-b-0', className)}
+      className={cn('border-b border-border last:border-b-0', className)}
       {...props}
     />
   )
@@ -35,13 +35,13 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          'flex flex-1 items-start justify-between gap-4 rounded-md bg-gray-800 py-4 text-left text-sm font-medium text-gray-100 outline-none transition-all duration-200 hover:bg-gray-700 focus-visible:ring-2 focus-visible:ring-gold-500 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
+          'flex flex-1 items-start justify-between gap-4 rounded-md bg-muted py-4 text-left text-sm font-medium text-foreground outline-none transition-all duration-200 hover:bg-accent focus-visible:ring-2 focus-visible:ring-gold-500 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
           className,
         )}
         {...props}
       >
         {children}
-        <ChevronDownIcon className="pointer-events-none size-4 shrink-0 translate-y-0.5 text-gray-400 transition-transform duration-200" />
+        <ChevronDownIcon className="pointer-events-none size-4 shrink-0 translate-y-0.5 text-muted-foreground transition-transform duration-200" />
       </AccordionPrimitive.Trigger>
     </AccordionPrimitive.Header>
   )
@@ -55,7 +55,7 @@ function AccordionContent({
   return (
     <AccordionPrimitive.Content
       data-slot="accordion-content"
-      className="overflow-hidden border-t border-gray-700 bg-gray-800 text-sm text-gray-200 data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+      className="overflow-hidden border-t border-border bg-muted text-sm text-foreground data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
       {...props}
     >
       <div className={cn('pb-4 pt-0', className)}>{children}</div>

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -59,8 +59,8 @@ function AlertDialogContent({
           'grid gap-4',
 
           // Minimal/Clean Flowbite style
-          'bg-gray-900',
-          'border border-gray-700',
+          'bg-background',
+          'border border-border',
           'rounded-lg',
           'p-6',
 
@@ -90,8 +90,8 @@ function AlertDialogHeader({
       data-slot="alert-dialog-header"
       className={cn(
         'flex flex-col gap-2 text-center sm:text-left',
-        'bg-gray-800',
-        'border-b border-gray-700',
+        'bg-muted',
+        'border-b border-border',
         'p-6',
         '-mx-6 -mt-6 mb-2',
         className
@@ -110,8 +110,8 @@ function AlertDialogFooter({
       data-slot="alert-dialog-footer"
       className={cn(
         'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
-        'bg-gray-800',
-        'border-t border-gray-700',
+        'bg-muted',
+        'border-t border-border',
         'p-6',
         '-mx-6 -mb-6 mt-2',
         className,
@@ -130,7 +130,7 @@ function AlertDialogTitle({
       data-slot="alert-dialog-title"
       className={cn(
         'text-2xl leading-none font-semibold',
-        'text-gray-50',
+        'text-foreground',
         className
       )}
       {...props}
@@ -145,7 +145,7 @@ function AlertDialogDescription({
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
-      className={cn('text-sm text-gray-400', className)}
+      className={cn('text-sm text-muted-foreground', className)}
       {...props}
     />
   )
@@ -189,10 +189,10 @@ function AlertDialogCancel({
         'rounded-lg',
         'px-5 py-2.5',
         'text-sm font-medium',
-        'text-gray-300',
-        'border border-gray-600',
-        'bg-transparent hover:bg-gray-800',
-        'focus:outline-none focus:ring-4 focus:ring-gray-700',
+        'text-foreground',
+        'border border-border',
+        'bg-transparent hover:bg-accent',
+        'focus:outline-none focus:ring-4 focus:ring-ring',
         'transition-colors',
         'disabled:opacity-50 disabled:pointer-events-none',
         className

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -12,11 +12,11 @@ const badgeVariants = cva(
         default:
           'border-transparent bg-gold-600 text-white [a&]:hover:bg-gold-700 focus-visible:ring-gold-500',
         secondary:
-          'border-transparent bg-gray-700 text-gray-200 [a&]:hover:bg-gray-600 focus-visible:ring-gray-500',
+          'border-transparent bg-muted text-foreground [a&]:hover:bg-accent focus-visible:ring-ring',
         destructive:
           'border-transparent bg-red-600 text-white [a&]:hover:bg-red-700 focus-visible:ring-red-500',
         outline:
-          'border-gray-600 text-gray-300 bg-transparent [a&]:hover:bg-gray-800 [a&]:hover:border-gray-500 focus-visible:ring-gray-500',
+          'border-border text-foreground bg-transparent [a&]:hover:bg-accent [a&]:hover:border-border focus-visible:ring-ring',
         warning:
           'border-transparent bg-yellow-600 text-white [a&]:hover:bg-yellow-700 focus-visible:ring-yellow-500',
       },

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -9,9 +9,9 @@ const buttonVariants = cva(
       variant: {
         default: 'bg-gold-600 hover:bg-gold-700 text-white focus:ring-gold-300 shadow-sm hover:shadow-md',
         primary: 'bg-gradient-to-r from-gold-600 to-gold-700 hover:from-gold-700 hover:to-gold-800 text-white focus:ring-gold-300 shadow-sm hover:shadow-md',
-        secondary: 'bg-gray-800 hover:bg-gray-700 text-gray-100 focus:ring-gray-700 shadow-sm hover:shadow-md',
-        outline: 'border border-gray-600 bg-transparent hover:bg-gray-800 text-gray-300 focus:ring-gray-700',
-        ghost: 'bg-transparent hover:bg-gray-800 text-gray-300 focus:ring-gray-700',
+        secondary: 'bg-muted hover:bg-accent text-foreground focus:ring-ring shadow-sm hover:shadow-md',
+        outline: 'border border-border bg-transparent hover:bg-accent text-foreground focus:ring-ring',
+        ghost: 'bg-transparent hover:bg-accent text-foreground focus:ring-ring',
         destructive: 'bg-red-600 hover:bg-red-700 text-white focus:ring-red-300 shadow-sm hover:shadow-md',
       },
       size: {

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -8,7 +8,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'rounded-lg border border-gray-700 bg-gray-800 shadow-sm',
+      'rounded-lg border border-border bg-card shadow-sm',
       'transition-shadow duration-200',
       'hover:shadow-md',
       className
@@ -37,7 +37,7 @@ const CardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={cn(
-      'text-2xl font-semibold leading-tight text-gray-100',
+      'text-2xl font-semibold leading-tight text-foreground',
       className
     )}
     {...props}
@@ -51,7 +51,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn('text-sm text-gray-400', className)}
+    className={cn('text-sm text-muted-foreground', className)}
     {...props}
   />
 ))

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -14,7 +14,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        'peer size-4 shrink-0 rounded border border-gray-600 bg-gray-800 shadow-xs',
+        'peer size-4 shrink-0 rounded border border-border bg-muted shadow-xs',
         'transition-all duration-200 outline-none',
         'focus:ring-4 focus:ring-gold-300 focus:border-gold-500',
         'data-[state=checked]:bg-gold-600 data-[state=checked]:border-gold-600 data-[state=checked]:text-white',

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -66,8 +66,8 @@ function DialogContent({
           'grid gap-4',
 
           // Minimal/Clean style
-          'bg-gray-900',
-          'border border-gray-700',
+          'bg-background',
+          'border border-border',
           'rounded-lg',
 
           // Subtle shadow
@@ -114,8 +114,8 @@ function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
       data-slot="dialog-header"
       className={cn(
         'flex flex-col gap-2 text-center sm:text-left',
-        'bg-gray-800',
-        'border-b border-gray-700',
+        'bg-muted',
+        'border-b border-border',
         'p-6',
         '-mx-4 -mt-4 mb-2',
         className
@@ -131,8 +131,8 @@ function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
       data-slot="dialog-footer"
       className={cn(
         'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
-        'bg-gray-800',
-        'border-t border-gray-700',
+        'bg-muted',
+        'border-t border-border',
         'p-6',
         '-mx-4 -mb-4 mt-2',
         className,
@@ -151,7 +151,7 @@ function DialogTitle({
       data-slot="dialog-title"
       className={cn(
         'text-2xl leading-none font-semibold',
-        'text-gray-50',
+        'text-foreground',
         className
       )}
       {...props}
@@ -166,7 +166,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn('text-sm text-gray-400', className)}
+      className={cn('text-sm text-muted-foreground', className)}
       {...props}
     />
   )

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -10,9 +10,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-lg border border-gray-600',
-          'bg-gray-800 px-3 py-2 text-sm text-gray-100',
-          'placeholder:text-gray-400',
+          'flex h-10 w-full rounded-lg border border-border',
+          'bg-muted px-3 py-2 text-sm text-foreground',
+          'placeholder:text-muted-foreground',
           'focus:outline-none focus:ring-4 focus:ring-gold-300 focus:border-gold-500',
           'disabled:cursor-not-allowed disabled:opacity-50',
           'transition-all duration-200',

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -13,7 +13,7 @@ function Label({
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        'flex items-center gap-2 text-sm font-medium leading-none text-gray-200 select-none',
+        'flex items-center gap-2 text-sm font-medium leading-none text-foreground select-none',
         'group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50',
         'peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
         className,

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -59,7 +59,7 @@ function PaginationLink({
           size,
         }),
         isActive && 'bg-gold-600 text-white hover:bg-gold-700 border-transparent',
-        !isActive && 'text-gray-100 hover:bg-gray-700',
+        !isActive && 'text-foreground hover:bg-muted',
         'transition-all duration-200',
         className,
       )}

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -14,7 +14,7 @@ function Progress({
     <ProgressPrimitive.Root
       data-slot="progress"
       className={cn(
-        'relative h-2 w-full overflow-hidden rounded-full bg-gray-700',
+        'relative h-2 w-full overflow-hidden rounded-full bg-muted',
         className,
       )}
       {...props}

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -38,7 +38,7 @@ function ScrollBar({
       data-slot="scroll-area-scrollbar"
       orientation={orientation}
       className={cn(
-        'flex touch-none select-none bg-gray-700 p-px transition-colors',
+        'flex touch-none select-none bg-muted p-px transition-colors',
         orientation === 'vertical' &&
           'h-full w-2.5 border-l border-l-transparent',
         orientation === 'horizontal' &&
@@ -49,7 +49,7 @@ function ScrollBar({
     >
       <ScrollAreaPrimitive.ScrollAreaThumb
         data-slot="scroll-area-thumb"
-        className="relative flex-1 rounded-full bg-gray-600 hover:bg-gray-500 transition-colors duration-200"
+        className="relative flex-1 rounded-full bg-muted-foreground/50 hover:bg-muted-foreground/70 transition-colors duration-200"
       />
     </ScrollAreaPrimitive.ScrollAreaScrollbar>
   )

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -37,20 +37,20 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        'flex w-fit items-center justify-between gap-2 rounded-lg border border-gray-600',
-        'bg-gray-800 px-3 py-2 text-sm text-gray-100 whitespace-nowrap',
+        'flex w-fit items-center justify-between gap-2 rounded-lg border border-border',
+        'bg-muted px-3 py-2 text-sm text-foreground whitespace-nowrap',
         'shadow-xs transition-all duration-200 outline-none',
         'focus:ring-4 focus:ring-gold-300 focus:border-gold-500',
-        'hover:bg-gray-700',
+        'hover:bg-accent',
         'disabled:cursor-not-allowed disabled:opacity-50',
-        'data-[placeholder]:text-gray-400',
+        'data-[placeholder]:text-muted-foreground',
         'data-[size=default]:h-9 data-[size=sm]:h-8',
         '*:data-[slot=select-value]:line-clamp-1',
         '*:data-[slot=select-value]:flex',
         '*:data-[slot=select-value]:items-center',
         '*:data-[slot=select-value]:gap-2',
         '[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4',
-        '[&_svg:not([class*=\'text-\'])]:text-gray-400',
+        '[&_svg:not([class*=\'text-\'])]:text-muted-foreground',
         className,
       )}
       {...props}
@@ -76,7 +76,7 @@ function SelectContent({
         className={cn(
           'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem]',
           'origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto',
-          'rounded-lg border border-gray-700 bg-gray-800 text-gray-100 shadow-md',
+          'rounded-lg border border-border bg-card text-foreground shadow-md',
           'data-[state=open]:animate-in data-[state=closed]:animate-out',
           'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
           'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
@@ -112,7 +112,7 @@ function SelectLabel({
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn('px-2 py-1.5 text-xs text-gray-400', className)}
+      className={cn('px-2 py-1.5 text-xs text-muted-foreground', className)}
       {...props}
     />
   )
@@ -129,10 +129,10 @@ function SelectItem({
       className={cn(
         'relative flex w-full cursor-default items-center gap-2 rounded-sm',
         'py-1.5 pr-8 pl-2 text-sm outline-hidden select-none',
-        'focus:bg-gray-700 focus:text-gray-100',
+        'focus:bg-accent focus:text-foreground',
         'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
         '[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4',
-        '[&_svg:not([class*=\'text-\'])]:text-gray-400',
+        '[&_svg:not([class*=\'text-\'])]:text-muted-foreground',
         '*:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2',
         className,
       )}
@@ -155,7 +155,7 @@ function SelectSeparator({
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
-      className={cn('pointer-events-none -mx-1 my-1 h-px bg-gray-700', className)}
+      className={cn('pointer-events-none -mx-1 my-1 h-px bg-border', className)}
       {...props}
     />
   )

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="skeleton"
-      className={cn('animate-pulse rounded-md bg-gray-700', className)}
+      className={cn('animate-pulse rounded-md bg-muted', className)}
       {...props}
     />
   )

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -9,9 +9,9 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          'flex min-h-[80px] w-full rounded-lg border border-gray-600',
-          'bg-gray-800 px-3 py-2 text-sm text-gray-100',
-          'placeholder:text-gray-400',
+          'flex min-h-[80px] w-full rounded-lg border border-border',
+          'bg-muted px-3 py-2 text-sm text-foreground',
+          'placeholder:text-muted-foreground',
           'focus:outline-none focus:ring-4 focus:ring-gold-300 focus:border-gold-500',
           'disabled:cursor-not-allowed disabled:opacity-50',
           'transition-all duration-200',


### PR DESCRIPTION
## Summary

- 프로젝트 전체에 다크모드/라이트모드 토글 기능 추가
- 헤더에 테마 토글 버튼 추가 (라이트/다크/시스템 3가지 옵션)
- 60개 이상의 컴포넌트에서 하드코딩된 gray 색상을 CSS 변수 기반으로 변환

## Changes

### 테마 시스템
- `globals.css`: CSS 변수 라이트/다크 모드 분리
- `Providers.tsx`: next-themes 설정 (enableSystem, defaultTheme="system")
- `ThemeToggle.tsx`: 새 테마 토글 컴포넌트

### 색상 변환 (60+ 파일)
- `bg-gray-900` → `bg-background`
- `bg-gray-800` → `bg-card` / `bg-muted`
- `text-gray-100` → `text-foreground`
- `text-gray-400` → `text-muted-foreground`
- `border-gray-700` → `border-border`

### 수정된 주요 영역
- Archive 페이지 (tournament, cash-game, 모든 컴포넌트)
- Players 페이지 및 통계 카드
- Search 페이지 및 필터
- Community 페이지
- UI 컴포넌트 (input, button, dialog, card 등)
- Admin 페이지

## Test plan

- [ ] 헤더 테마 토글 버튼 클릭 시 라이트/다크/시스템 모드 전환 확인
- [ ] 모바일 메뉴에서 테마 변경 확인
- [ ] 토너먼트 페이지 라이트 모드 배경색 확인
- [ ] 모든 주요 페이지에서 테마 일관성 확인
- [ ] 골드 악센트 색상 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)